### PR TITLE
Rename `MainReducer` to `CombinedReducer` and Add Tests

### DIFF
--- a/SwiftFlow.xcodeproj/project.pbxproj
+++ b/SwiftFlow.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		621C06501C276FF0008029AE /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621C06271C276F58008029AE /* Nimble.framework */; };
 		621C06511C276FF0008029AE /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621C06451C276F63008029AE /* Quick.framework */; };
+		621C06861C277759008029AE /* CombinedReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C06851C277759008029AE /* CombinedReducerTests.swift */; };
 		625E66871C1FF97E0027C288 /* SwiftFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* SwiftFlow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* SwiftFlow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* SwiftFlow.framework */; };
 		625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66A61C1FFA640027C288 /* StoreTests.swift */; };
@@ -20,7 +21,7 @@
 		625E66BF1C1FFC880027C288 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66B91C1FFC880027C288 /* State.swift */; };
 		625E66C01C1FFC880027C288 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66BA1C1FFC880027C288 /* Store.swift */; };
 		625E66C11C1FFC880027C288 /* StoreSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */; };
-		625E67061C20032E0027C288 /* MainReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* MainReducer.swift */; };
+		625E67061C20032E0027C288 /* CombinedReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 625E67051C20032E0027C288 /* CombinedReducer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,6 +142,7 @@
 /* Begin PBXFileReference section */
 		621C061D1C276F58008029AE /* Nimble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Nimble.xcodeproj; path = Carthage/Checkouts/Nimble/Nimble.xcodeproj; sourceTree = "<group>"; };
 		621C06321C276F63008029AE /* Quick.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Quick.xcodeproj; path = Carthage/Checkouts/Quick/Quick.xcodeproj; sourceTree = "<group>"; };
+		621C06851C277759008029AE /* CombinedReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedReducerTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* SwiftFlow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFlow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		625E66861C1FF97E0027C288 /* SwiftFlow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftFlow.h; sourceTree = "<group>"; };
 		625E66881C1FF97E0027C288 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -155,7 +157,7 @@
 		625E66B91C1FFC880027C288 /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		625E66BA1C1FFC880027C288 /* Store.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreSubscriber.swift; sourceTree = "<group>"; };
-		625E67051C20032E0027C288 /* MainReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainReducer.swift; sourceTree = "<group>"; };
+		625E67051C20032E0027C288 /* CombinedReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedReducer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +254,7 @@
 			children = (
 				621C06181C276A5A008029AE /* Frameworks */,
 				625E66A61C1FFA640027C288 /* StoreTests.swift */,
+				621C06851C277759008029AE /* CombinedReducerTests.swift */,
 				625E669E1C1FFA3C0027C288 /* Info.plist */,
 			);
 			path = SwiftFlowTests;
@@ -269,7 +272,7 @@
 		625E66B51C1FFC880027C288 /* CoreTypes */ = {
 			isa = PBXGroup;
 			children = (
-				625E67051C20032E0027C288 /* MainReducer.swift */,
+				625E67051C20032E0027C288 /* CombinedReducer.swift */,
 				625E66B61C1FFC880027C288 /* Action.swift */,
 				625E66B71C1FFC880027C288 /* MainStore.swift */,
 				625E66B81C1FFC880027C288 /* Reducer.swift */,
@@ -530,7 +533,7 @@
 				625E66BC1C1FFC880027C288 /* Action.swift in Sources */,
 				625E66BE1C1FFC880027C288 /* Reducer.swift in Sources */,
 				625E66B41C1FFC830027C288 /* TypeHelper.swift in Sources */,
-				625E67061C20032E0027C288 /* MainReducer.swift in Sources */,
+				625E67061C20032E0027C288 /* CombinedReducer.swift in Sources */,
 				625E66BF1C1FFC880027C288 /* State.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -540,6 +543,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				625E66A71C1FFA640027C288 /* StoreTests.swift in Sources */,
+				621C06861C277759008029AE /* CombinedReducerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftFlow/CoreTypes/Action.swift
+++ b/SwiftFlow/CoreTypes/Action.swift
@@ -33,6 +33,8 @@ public struct Action: ActionType {
 
 }
 
+// MARK: Coding Extension
+
 extension Action: Coding {
 
     public init(dictionary: [String : AnyObject]) {

--- a/SwiftFlow/CoreTypes/CombinedReducer.swift
+++ b/SwiftFlow/CoreTypes/CombinedReducer.swift
@@ -10,18 +10,16 @@ import Foundation
 
 public struct CombinedReducer: AnyReducer {
 
-    let reducers: [AnyReducer]
+    private let reducers: [AnyReducer]
 
     public init(_ reducers: [AnyReducer]) {
         self.reducers = reducers
     }
 
-    public func _handleAction(var state: StateType, action: Action) -> StateType {
-        reducers.forEach { reducer in
-            state = reducer._handleAction(state, action: action)
+    public func _handleAction(state: StateType, action: Action) -> StateType {
+        return reducers.reduce(state) { currentState, reducer in
+            reducer._handleAction(currentState, action: action)
         }
-
-        return state
     }
 
 }

--- a/SwiftFlow/CoreTypes/CombinedReducer.swift
+++ b/SwiftFlow/CoreTypes/CombinedReducer.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public struct MainReducer: AnyReducer {
+public struct CombinedReducer: AnyReducer {
 
-    var reducers: [AnyReducer]
+    let reducers: [AnyReducer]
 
     public init(_ reducers: [AnyReducer]) {
         self.reducers = reducers

--- a/SwiftFlowTests/CombinedReducerTests.swift
+++ b/SwiftFlowTests/CombinedReducerTests.swift
@@ -1,0 +1,85 @@
+//
+//  CombinedReducerTests.swift
+//  SwiftFlow
+//
+//  Created by Benjamin Encz on 12/20/15.
+//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import SwiftFlow
+
+class MockReducer: Reducer {
+
+    var calledWithAction: [Action] = []
+
+    func handleAction(state: StateType, action: Action) -> StateType {
+        calledWithAction.append(action)
+
+        return state
+    }
+
+}
+
+class IncreaseByOneReducer: Reducer {
+    func handleAction(state: CounterState, action: Action) -> CounterState {
+        var newState = state
+        newState.count = state.count + 1
+
+        return newState
+    }
+}
+
+class IncreaseByTwoReducer: Reducer {
+    func handleAction(state: CounterState, action: Action) -> CounterState {
+        var newState = state
+        newState.count = state.count + 2
+
+        return newState
+    }
+}
+
+struct CounterState: StateType {
+    var count: Int = 0
+}
+
+let emptyAction = "EMPTY_ACTION"
+
+// swiftlint:disable function_body_length
+class CombinedReducerSpecs: QuickSpec {
+
+    override func spec() {
+        describe("Combined Reducer") {
+
+            it("calls each of the reducers with the given action exactly once") {
+                let mockReducer1 = MockReducer()
+                let mockReducer2 = MockReducer()
+
+                let combinedReducer = CombinedReducer([mockReducer1, mockReducer2])
+
+                combinedReducer._handleAction(CounterState(), action: Action(emptyAction))
+
+                expect(mockReducer1.calledWithAction).to(haveCount(1))
+                expect(mockReducer2.calledWithAction).to(haveCount(1))
+                expect(mockReducer1.calledWithAction[0].type).to(equal(emptyAction))
+                expect(mockReducer2.calledWithAction[0].type).to(equal(emptyAction))
+            }
+
+            it("combines the results from each individual reducer correctly") {
+                let increaseByOneReducer = IncreaseByOneReducer()
+                let increaseByTwoReducer = IncreaseByTwoReducer()
+
+                let combinedReducer = CombinedReducer([increaseByOneReducer, increaseByTwoReducer])
+                let newState = combinedReducer._handleAction(CounterState(),
+                    action: Action(emptyAction)) as? CounterState
+
+                expect(newState?.count).to(equal(3))
+            }
+
+        }
+    }
+
+}
+// swiftlint:enable function_body_length


### PR DESCRIPTION
**API Changes**:
- `MainReducer` is now called `CombinedReducer`

Additional Changes:

- PR includes test for new `CombinedReducer`
- Implementation now uses Swift's `reduce` instead of a `forEach` loop