### PR TITLE
Dispatch Actions Synchronously

### DIFF
--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -29,6 +29,7 @@ public class MainStore: Store {
 
     private var reducer: AnyReducer
     private var subscribers: [AnyStoreSubscriber] = []
+    private var isDispatching = false
 
     public required init(reducer: AnyReducer, appState: StateType) {
         self.reducer = reducer
@@ -62,7 +63,16 @@ public class MainStore: Store {
     }
 
     public func _defaultDispatch(action: ActionType) -> Any {
+        if isDispatching {
+            // Use Obj-C exception since throwing of exceptions can be verified through tests
+            NSException.raise("SwiftFlow:IllegalDispatchFromReducer", format: "Reducers are not " +
+                "allowed to dispatch actions!", arguments: getVaList(["nil"]))
+        }
+
+        isDispatching = true
         self.appState = self.reducer._handleAction(self.appState, action: action.toAction())
+        isDispatching = false
+
         return action
     }
 

--- a/SwiftFlowTests/StoreMiddlewareTests.swift
+++ b/SwiftFlowTests/StoreMiddlewareTests.swift
@@ -76,8 +76,8 @@ class StoreMiddlewareSpecs: QuickSpec {
                 let action = SetValueStringAction("OK")
                 store.dispatch(action)
 
-                expect((store.appState as! TestStringAppState).testValue).toEventually(
-                    equal("OK First Middleware Second Middleware"), timeout: 2.0)
+                expect((store.appState as! TestStringAppState).testValue).to(
+                    equal("OK First Middleware Second Middleware"))
             }
 
             it("can dispatch actions") {
@@ -91,8 +91,8 @@ class StoreMiddlewareSpecs: QuickSpec {
                 let action = SetValueAction(10)
                 store.dispatch(action)
 
-                expect((store.appState as! TestStringAppState).testValue).toEventually(
-                    equal("10 First Middleware Second Middleware"), timeout: 2.0)
+                expect((store.appState as! TestStringAppState).testValue).to(
+                    equal("10 First Middleware Second Middleware"))
             }
 
             it("can change the return value of the dispatch function") {

--- a/SwiftFlowTests/StoreTests.swift
+++ b/SwiftFlowTests/StoreTests.swift
@@ -32,17 +32,12 @@ class StoreSpecs: QuickSpec {
                 let subscriber = TestStoreSubscriber<TestAppState>()
 
                 store.subscribe(subscriber)
+                store.dispatch(SetValueAction(3))
 
-                waitUntil(timeout: 2.0) { fulfill in
-                    store.dispatch(SetValueAction(3)) { newState in
-                        if subscriber.receivedStates.last?.testValue == 3 {
-                            fulfill()
-                        }
-                    }
-                }
+                expect(subscriber.receivedStates.last?.testValue).to(equal(3))
             }
 
-            xit("does not dispatch value after subscriber unsubscribes") {
+            it("does not dispatch value after subscriber unsubscribes") {
                 store = MainStore(reducer: reducer, appState: TestAppState())
                 let subscriber = TestStoreSubscriber<TestAppState>()
 
@@ -50,33 +45,28 @@ class StoreSpecs: QuickSpec {
                 store.subscribe(subscriber)
                 store.dispatch(SetValueAction(10))
 
-                // Let Run Loop Run so that dispatched actions can be performed
-                NSRunLoop.currentRunLoop().runMode(NSDefaultRunLoopMode,
-                    beforeDate: NSDate.distantFuture())
-
                 store.unsubscribe(subscriber)
                 // Following value is missed due to not being subscribed:
                 store.dispatch(SetValueAction(15))
                 store.dispatch(SetValueAction(25))
 
-                // Let Run Loop Run so that dispatched actions can be performed
-                NSRunLoop.currentRunLoop().runMode(NSDefaultRunLoopMode,
-                    beforeDate: NSDate.distantFuture())
-
                 store.subscribe(subscriber)
 
-                waitUntil(timeout: 2.0) { fulfill in
-                    store.dispatch(SetValueAction(20)) { newState in
-                        if subscriber.receivedStates[subscriber.receivedStates.count - 1]
-                            .testValue == 20
-                            && subscriber.receivedStates[subscriber.receivedStates.count - 2]
-                                .testValue == 25
-                            && subscriber.receivedStates[subscriber.receivedStates.count - 3]
-                                .testValue == 10 {
-                                    fulfill()
-                        }
-                    }
-                }
+                store.dispatch(SetValueAction(20))
+
+                expect(subscriber.receivedStates.count).to(equal(4))
+
+                expect(subscriber.receivedStates[subscriber.receivedStates.count - 4]
+                    .testValue).to(equal(5))
+
+                expect(subscriber.receivedStates[subscriber.receivedStates.count - 3]
+                    .testValue).to(equal(10))
+
+                expect(subscriber.receivedStates[subscriber.receivedStates.count - 2]
+                    .testValue).to(equal(25))
+
+                expect(subscriber.receivedStates[subscriber.receivedStates.count - 1]
+                    .testValue).to(equal(20))
             }
 
         }

--- a/SwiftFlowTests/StoreTests.swift
+++ b/SwiftFlowTests/StoreTests.swift
@@ -88,9 +88,29 @@ class StoreSpecs: QuickSpec {
                 expect(returnValue.value).to(equal(action.value))
             }
 
+            fit("throws an exception when a reducer dispatches an action") {
+                let reducer = DispatchingReducer()
+                store = MainStore(reducer: reducer, appState: TestAppState())
+                reducer.store = store
+                store.dispatch(SetValueAction(10))
+            }
+
         }
 
     }
 
 }
+
+
+// Needs to be class so that shared reference can be modified to inject store
+class DispatchingReducer: Reducer {
+    var store: Store? = nil
+
+    func handleAction(state: TestAppState, action: Action) -> TestAppState {
+        expect(self.store?.dispatch(SetValueAction(20))).to(raiseException(named:
+            "SwiftFlow:IllegalDispatchFromReducer"))
+        return state
+    }
+}
+
 // swiftlint:enable function_body_length


### PR DESCRIPTION
This PR changes all tests from async to sync to reflect the changes in the way actions are dispatched. Further, dispatching from reducers now throws an exception. This implements the same guarantee that was earlier provided by async dispatch.