### PR TITLE
Rename Action Types and Change Store Interface

### DIFF
--- a/SwiftFlow/CoreTypes/Action.swift
+++ b/SwiftFlow/CoreTypes/Action.swift
@@ -8,45 +8,47 @@
 
 import Foundation
 
-public struct Action: ActionType {
+public struct StandardAction: Action {
     public let type: String
     public let payload: [String: AnyObject]?
+    /// Indicates whether this action will be deserialized as a typed action or as a standard action
+    public let isTypedAction: Bool
 
     public init(_ type: String) {
         self.type = type
         self.payload = nil
+        self.isTypedAction = false
     }
 
-    public init(type: String, payload: [String: AnyObject]) {
+    public init(type: String, payload: [String: AnyObject], isTypedAction: Bool = false) {
         self.type = type
         self.payload = payload
+        self.isTypedAction = isTypedAction
     }
 
-    public init(type: String, payload payloadConvertible: PayloadConvertible) {
-        self.type = type
-        self.payload = payloadConvertible.toPayload()
+    public init(type: String, payload payloadConvertible: PayloadConvertible,
+        isTypedAction: Bool = false) {
+            self.type = type
+            self.payload = payloadConvertible.toPayload()
+            self.isTypedAction = isTypedAction
     }
-
-    public func toAction() -> Action {
-        return self
-    }
-
 }
 
 // MARK: Coding Extension
 
-extension Action: Coding {
+extension StandardAction: Coding {
 
     public init(dictionary: [String : AnyObject]) {
         self.type = dictionary["type"] as! String
         self.payload = dictionary["payload"] as? [String: AnyObject]
+        self.isTypedAction = (dictionary["isTypedAction"] as! Int) == 1 ? true : false
     }
 
     public func dictionaryRepresentation() -> [String : AnyObject] {
         if let payload = payload {
-            return ["type": type, "payload": payload]
+            return ["type": type, "payload": payload, "isTypedAction": isTypedAction ? 1 : 0]
         } else {
-            return ["type": type, "payload": "null"]
+            return ["type": type, "payload": "null", "isTypedAction": isTypedAction ? 1 : 0]
         }
     }
 
@@ -56,11 +58,9 @@ public protocol PayloadConvertible {
     func toPayload() -> [String: AnyObject]
 }
 
-public protocol ActionConvertible: ActionType {
-    // TODO: this likely should be a failable or throwing initializer
-    init (_ action: Action)
+public protocol StandardActionConvertible: Action {
+    init (_ standardAction: StandardAction)
+    func toStandardAction() -> StandardAction
 }
 
-public protocol ActionType {
-    func toAction() -> Action
-}
+public protocol Action { }

--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -62,7 +62,7 @@ public class MainStore: Store {
         }
     }
 
-    public func _defaultDispatch(action: ActionType) -> Any {
+    public func _defaultDispatch(action: Action) -> Any {
         if isDispatching {
             // Use Obj-C exception since throwing of exceptions can be verified through tests
             NSException.raise("SwiftFlow:IllegalDispatchFromReducer", format: "Reducers may not " +
@@ -70,18 +70,14 @@ public class MainStore: Store {
         }
 
         isDispatching = true
-        self.appState = self.reducer._handleAction(self.appState, action: action.toAction())
+        self.appState = self.reducer._handleAction(self.appState, action: action)
         isDispatching = false
 
         return action
     }
 
-    public func dispatch(action: ActionType) -> Any {
+    public func dispatch(action: Action) -> Any {
         return dispatch(action, callback: nil)
-    }
-
-    public func dispatch(action: ActionConvertible) -> Any {
-        return dispatch(action.toAction(), callback: nil)
     }
 
     public func dispatch(actionCreatorProvider: ActionCreator) -> Any {
@@ -92,8 +88,8 @@ public class MainStore: Store {
         dispatch(asyncActionCreatorProvider, callback: nil)
     }
 
-    public func dispatch(action: ActionType, callback: DispatchCallback?) -> Any {
-        let returnValue = self.dispatchFunction(action.toAction())
+    public func dispatch(action: Action, callback: DispatchCallback?) -> Any {
+        let returnValue = self.dispatchFunction(action)
         callback?(self.appState)
 
         return returnValue

--- a/SwiftFlow/CoreTypes/Store.swift
+++ b/SwiftFlow/CoreTypes/Store.swift
@@ -51,7 +51,7 @@ public protocol Store {
      - returns: By default returns the dispatched action, but middlewares can change the
      return type, e.g. to return promises
      */
-    func dispatch(action: ActionType) -> Any
+    func dispatch(action: Action) -> Any
 
     /**
      Dispatches an action creator to the store. Action creators are functions that generate
@@ -107,13 +107,13 @@ public protocol Store {
      - returns: By default returns the dispatched action, but middlewares can change the
      return type, e.g. to return promises
      */
-    func dispatch(action: ActionType, callback: DispatchCallback?) -> Any
+    func dispatch(action: Action, callback: DispatchCallback?) -> Any
     func dispatch(actionCreatorProvider: ActionCreator, callback: DispatchCallback?) -> Any
     func dispatch(asyncActionCreatorProvider: AsyncActionCreator, callback: DispatchCallback?)
 }
 
 public typealias DispatchCallback = (StateType) -> Void
-public typealias ActionCreator = (state: StateType, store: Store) -> ActionType?
+public typealias ActionCreator = (state: StateType, store: Store) -> Action?
 
 /// AsyncActionCreators allow the developer to wait for the completion of an async action
 public typealias AsyncActionCreator = (state: StateType, store: Store,

--- a/SwiftFlowTests/CombinedReducerTests.swift
+++ b/SwiftFlowTests/CombinedReducerTests.swift
@@ -59,12 +59,14 @@ class CombinedReducerSpecs: QuickSpec {
 
                 let combinedReducer = CombinedReducer([mockReducer1, mockReducer2])
 
-                combinedReducer._handleAction(CounterState(), action: Action(emptyAction))
+                combinedReducer._handleAction(CounterState(), action: StandardAction(emptyAction))
 
                 expect(mockReducer1.calledWithAction).to(haveCount(1))
                 expect(mockReducer2.calledWithAction).to(haveCount(1))
-                expect(mockReducer1.calledWithAction[0].type).to(equal(emptyAction))
-                expect(mockReducer2.calledWithAction[0].type).to(equal(emptyAction))
+                expect((mockReducer1.calledWithAction[0] as! StandardAction).type)
+                    .to(equal(emptyAction))
+                expect((mockReducer2.calledWithAction[0] as! StandardAction).type)
+                    .to(equal(emptyAction))
             }
 
             it("combines the results from each individual reducer correctly") {
@@ -73,7 +75,7 @@ class CombinedReducerSpecs: QuickSpec {
 
                 let combinedReducer = CombinedReducer([increaseByOneReducer, increaseByTwoReducer])
                 let newState = combinedReducer._handleAction(CounterState(),
-                    action: Action(emptyAction)) as? CounterState
+                    action: StandardAction(emptyAction)) as? CounterState
 
                 expect(newState?.count).to(equal(3))
             }

--- a/SwiftFlowTests/StoreMiddlewareTests.swift
+++ b/SwiftFlowTests/StoreMiddlewareTests.swift
@@ -15,10 +15,9 @@ let firstMiddleware: Middleware = { dispatch, getState in
     return { next in
         return { action in
 
-            if action.type == SetValueStringAction.type {
-                var modifiedAction = SetValueStringAction(action)
-                modifiedAction.value = modifiedAction.value + " First Middleware"
-                return next(modifiedAction.toAction())
+            if var action = action as? SetValueStringAction {
+                action.value = action.value + " First Middleware"
+                return next(action)
             } else {
                 return next(action)
             }
@@ -30,10 +29,9 @@ let secondMiddleware: Middleware = { dispatch, getState in
     return { next in
         return { action in
 
-            if action.type == SetValueStringAction.type {
-                var modifiedAction = SetValueStringAction(action)
-                modifiedAction.value = modifiedAction.value + " Second Middleware"
-                return next(modifiedAction.toAction())
+            if var action = action as? SetValueStringAction {
+                action.value = action.value + " Second Middleware"
+                return next(action)
             } else {
                 return next(action)
             }
@@ -45,9 +43,8 @@ let dispatchingMiddleware: Middleware = { dispatch, getState in
     return { next in
         return { action in
 
-            if action.type == SetValueAction.type {
-                let valueAction = SetValueAction(action)
-                dispatch(SetValueStringAction("\(valueAction.value)").toAction())
+            if var action = action as? SetValueAction {
+                dispatch(SetValueStringAction("\(action.value)"))
 
                 return "Converted Action Successfully"
             }

--- a/SwiftFlowTests/StoreTests.swift
+++ b/SwiftFlowTests/StoreTests.swift
@@ -83,9 +83,9 @@ class StoreSpecs: QuickSpec {
 
             it("returns the dispatched action") {
                 let action = SetValueAction(10)
-                let returnValue = SetValueAction(store.dispatch(action) as! Action)
+                let returnValue = store.dispatch(action)
 
-                expect(returnValue.value).to(equal(action.value))
+                expect((returnValue as? SetValueAction)?.value).to(equal(action.value))
             }
 
             it("throws an exception when a reducer dispatches an action") {

--- a/SwiftFlowTests/TestFakes.swift
+++ b/SwiftFlowTests/TestFakes.swift
@@ -25,7 +25,7 @@ struct TestStringAppState: StateType {
     }
 }
 
-struct SetValueAction: ActionConvertible {
+struct SetValueAction: StandardActionConvertible {
 
     let value: Int
     static let type = "SetValueAction"
@@ -34,17 +34,17 @@ struct SetValueAction: ActionConvertible {
         self.value = value
     }
 
-    init(_ action: Action) {
-        self.value = action.payload!["value"] as! Int
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! Int
     }
 
-    func toAction() -> Action {
-        return Action(type: SetValueAction.type, payload: ["value": value])
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueAction.type, payload: ["value": value])
     }
 
 }
 
-struct SetValueStringAction: ActionConvertible {
+struct SetValueStringAction: StandardActionConvertible {
 
     var value: String
     static let type = "SetValueStringAction"
@@ -53,21 +53,21 @@ struct SetValueStringAction: ActionConvertible {
         self.value = value
     }
 
-    init(_ action: Action) {
-        self.value = action.payload!["value"] as! String
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! String
     }
 
-    func toAction() -> Action {
-        return Action(type: SetValueStringAction.type, payload: ["value": value])
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueStringAction.type, payload: ["value": value])
     }
 
 }
 
 struct TestReducer: Reducer {
     func handleAction(var state: TestAppState, action: Action) -> TestAppState {
-        switch action.type {
-        case SetValueAction.type:
-            state.testValue = SetValueAction(action).value
+        switch action {
+        case let action as SetValueAction:
+            state.testValue = action.value
             return state
         default:
             return state
@@ -77,9 +77,9 @@ struct TestReducer: Reducer {
 
 struct TestValueStringReducer: Reducer {
     func handleAction(var state: TestStringAppState, action: Action) -> TestStringAppState {
-        switch action.type {
-        case SetValueStringAction.type:
-            state.testValue = SetValueStringAction(action).value
+        switch action {
+        case let action as SetValueStringAction:
+            state.testValue = action.value
             return state
         default:
             return state

--- a/SwiftFlowTests/TypeHelperTests.swift
+++ b/SwiftFlowTests/TypeHelperTests.swift
@@ -28,7 +28,8 @@ class TypeHelper: QuickSpec {
                     return state
                 }
 
-                withSpecificTypes(AppState1(), action: Action(""), function: reducerFunction)
+                withSpecificTypes(AppState1(), action: StandardAction(""),
+                    function: reducerFunction)
 
                 expect(called).to(beTrue())
             }
@@ -41,7 +42,8 @@ class TypeHelper: QuickSpec {
                     return state
                 }
 
-                withSpecificTypes(AppState2(), action: Action(""), function: reducerFunction)
+                withSpecificTypes(AppState2(), action: StandardAction(""),
+                    function: reducerFunction)
 
                 expect(called).to(beFalse())
             }


### PR DESCRIPTION
Solves #15. Store now works with typed actions again.