### PR TITLE
[Fix] Dispatching is Allowed from StoreSubscribers

### DIFF
--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -70,8 +70,10 @@ public class MainStore: Store {
         }
 
         isDispatching = true
-        self.appState = self.reducer._handleAction(self.appState, action: action)
+        let newState = self.reducer._handleAction(self.appState, action: action)
         isDispatching = false
+
+        self.appState = newState
 
         return action
     }

--- a/SwiftFlowTests/StoreTests.swift
+++ b/SwiftFlowTests/StoreTests.swift
@@ -37,6 +37,15 @@ class StoreSpecs: QuickSpec {
                 expect(subscriber.receivedStates.last?.testValue).to(equal(3))
             }
 
+            it("allows dispatching from within an observer") {
+                store = MainStore(reducer: reducer, appState: TestAppState())
+                store.subscribe(DispatchingSubscriber(store: store))
+
+                store.dispatch(SetValueAction(2))
+
+                expect((store.appState as? TestAppState)?.testValue).to(equal(5))
+            }
+
             it("does not dispatch value after subscriber unsubscribes") {
                 store = MainStore(reducer: reducer, appState: TestAppState())
                 let subscriber = TestStoreSubscriber<TestAppState>()

--- a/SwiftFlowTests/TestFakes.swift
+++ b/SwiftFlowTests/TestFakes.swift
@@ -96,3 +96,19 @@ class TestStoreSubscriber<T>: StoreSubscriber {
         receivedStates.append(state)
     }
 }
+
+class DispatchingSubscriber: StoreSubscriber {
+    var store: Store
+
+    init(store: Store) {
+        self.store = store
+    }
+
+    func newState(state: TestAppState) {
+        // Test if we've already dispatched this action to
+        // avoid endless recursion
+        if state.testValue != 5 {
+            self.store.dispatch(SetValueAction(5))
+        }
+    }
+}


### PR DESCRIPTION
Dispatch should only be forbidden from within Reducers. The previos implementation incorrectly also threw an exception when dispatching from within a StoreSubscriber.