### PR TITLE
Remove reduntant constructor from Store protocol

### DIFF
--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -31,19 +31,11 @@ public class MainStore: Store {
     private var subscribers: [AnyStoreSubscriber] = []
     private var isDispatching = false
 
-    public required init(reducer: AnyReducer, appState: StateType) {
+    public required init(reducer: AnyReducer, appState: StateType, middleware: [Middleware] = []) {
         self.reducer = reducer
         self.appState = appState
-        self.dispatchFunction = self._defaultDispatch
-    }
-
-    public required init(reducer: AnyReducer, appState: StateType, middleware: [Middleware]) {
-        self.reducer = reducer
-        self.appState = appState
-        self.dispatchFunction = self._defaultDispatch
-
         // Wrap the dispatch function with all middlewares
-        self.dispatchFunction = middleware.reverse().reduce(self.dispatchFunction) {
+        self.dispatchFunction = middleware.reverse().reduce(self._defaultDispatch) {
             dispatchFunction, middleware in
                 return middleware(self.dispatch, { self.appState })(dispatchFunction)
         }

--- a/SwiftFlow/CoreTypes/Store.swift
+++ b/SwiftFlow/CoreTypes/Store.swift
@@ -10,8 +10,6 @@ import Foundation
 
 public protocol Store {
 
-    init(reducer: AnyReducer, appState: StateType)
-
     init(reducer: AnyReducer, appState: StateType, middleware: [Middleware])
 
     /// The current state stored in the store


### PR DESCRIPTION
Simplifies public interface of the ```Store``` and removes kind of duplication in ```MainStore``` implementation.

The tests are passing, CI build is broken due carthage/github issues.