### PR TITLE
Ignore multiple identical subscribers

### DIFF
--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -38,10 +38,9 @@ public class MainStore: Store {
     public required init(reducer: AnyReducer, appState: StateType, middleware: [Middleware]) {
         self.reducer = reducer
         self.appState = appState
-        self.dispatchFunction = self._defaultDispatch
 
         // Wrap the dispatch function with all middlewares
-        self.dispatchFunction = middleware.reverse().reduce(self.dispatchFunction) {
+        self.dispatchFunction = middleware.reverse().reduce(self._defaultDispatch) {
             dispatchFunction, middleware in
                 return middleware(self.dispatch, { self.appState })(dispatchFunction)
         }

--- a/SwiftFlow/CoreTypes/MainStore.swift
+++ b/SwiftFlow/CoreTypes/MainStore.swift
@@ -28,7 +28,7 @@ public class MainStore: Store {
     public var dispatchFunction: DispatchFunction!
 
     private var reducer: AnyReducer
-    private var subscribers: [AnyStoreSubscriber] = []
+    var subscribers: [AnyStoreSubscriber] = []
     private var isDispatching = false
 
     public required convenience init(reducer: AnyReducer, appState: StateType) {
@@ -47,6 +47,11 @@ public class MainStore: Store {
     }
 
     public func subscribe(subscriber: AnyStoreSubscriber) {
+        guard subscribers.indexOf({ $0 === subscriber }) == nil else {
+            print("Store subscriber is already added, ignoring.")
+            return
+        }
+
         subscribers.append(subscriber)
         subscriber._newState(appState)
     }

--- a/SwiftFlowTests/StoreTests.swift
+++ b/SwiftFlowTests/StoreTests.swift
@@ -19,7 +19,7 @@ class StoreSpecs: QuickSpec {
 
         describe("#subscribe") {
 
-            var store: Store!
+            var store: MainStore!
             var reducer: TestReducer!
 
             beforeEach {
@@ -76,6 +76,16 @@ class StoreSpecs: QuickSpec {
 
                 expect(subscriber.receivedStates[subscriber.receivedStates.count - 1]
                     .testValue).to(equal(20))
+            }
+
+            it("ignores identical subscribers") {
+                store = MainStore(reducer: reducer, appState: TestAppState())
+                let subscriber = TestStoreSubscriber<TestAppState>()
+
+                store.subscribe(subscriber)
+                store.subscribe(subscriber)
+
+                expect(store.subscribers.count).to(equal(1))
             }
 
         }


### PR DESCRIPTION
I had to make ```subscribers``` internaly visible in order to test it.