### PR TITLE
Invert subscription transforms in a reactive way (attempt No. 2)

### DIFF
--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -53,6 +53,42 @@
 		25DBCFA01C30C50000D63A58 /* TestFakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259737FA1C2C618A00869B8F /* TestFakes.swift */; };
 		3F13C0EB1E7B3E4000D8442C /* SwiftLintIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F13C0EA1E7B3E4000D8442C /* SwiftLintIntegration.swift */; };
 		3F13C0ED1E7B3E4000D8442C /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
+		50F87AD522F5B5610064BEFA /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD422F5B5610064BEFA /* Select.swift */; };
+		50F87AD622F5B5610064BEFA /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD422F5B5610064BEFA /* Select.swift */; };
+		50F87AD722F5B5610064BEFA /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD422F5B5610064BEFA /* Select.swift */; };
+		50F87AD822F5B5610064BEFA /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD422F5B5610064BEFA /* Select.swift */; };
+		50F87ADA22F5B8010064BEFA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD922F5B8010064BEFA /* Observable.swift */; };
+		50F87ADB22F5B8010064BEFA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD922F5B8010064BEFA /* Observable.swift */; };
+		50F87ADC22F5B8010064BEFA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD922F5B8010064BEFA /* Observable.swift */; };
+		50F87ADD22F5B8010064BEFA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD922F5B8010064BEFA /* Observable.swift */; };
+		50F87ADF22F5B82A0064BEFA /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87ADE22F5B82A0064BEFA /* Producer.swift */; };
+		50F87AE022F5B82A0064BEFA /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87ADE22F5B82A0064BEFA /* Producer.swift */; };
+		50F87AE122F5B82A0064BEFA /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87ADE22F5B82A0064BEFA /* Producer.swift */; };
+		50F87AE222F5B82A0064BEFA /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87ADE22F5B82A0064BEFA /* Producer.swift */; };
+		50F87AE422F5B8930064BEFA /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE322F5B8930064BEFA /* Disposable.swift */; };
+		50F87AE522F5B8930064BEFA /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE322F5B8930064BEFA /* Disposable.swift */; };
+		50F87AE622F5B8930064BEFA /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE322F5B8930064BEFA /* Disposable.swift */; };
+		50F87AE722F5B8930064BEFA /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE322F5B8930064BEFA /* Disposable.swift */; };
+		50F87AE922F5B8AC0064BEFA /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE822F5B8AC0064BEFA /* Observer.swift */; };
+		50F87AEA22F5B8AC0064BEFA /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE822F5B8AC0064BEFA /* Observer.swift */; };
+		50F87AEB22F5B8AC0064BEFA /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE822F5B8AC0064BEFA /* Observer.swift */; };
+		50F87AEC22F5B8AC0064BEFA /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AE822F5B8AC0064BEFA /* Observer.swift */; };
+		50F87AEF22F5B8E80064BEFA /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AEE22F5B8E80064BEFA /* Sink.swift */; };
+		50F87AF022F5B8E80064BEFA /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AEE22F5B8E80064BEFA /* Sink.swift */; };
+		50F87AF122F5B8E80064BEFA /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AEE22F5B8E80064BEFA /* Sink.swift */; };
+		50F87AF222F5B8E80064BEFA /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AEE22F5B8E80064BEFA /* Sink.swift */; };
+		50F87AF422F5B9220064BEFA /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF322F5B9220064BEFA /* Cancelable.swift */; };
+		50F87AF522F5B9220064BEFA /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF322F5B9220064BEFA /* Cancelable.swift */; };
+		50F87AF622F5B9220064BEFA /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF322F5B9220064BEFA /* Cancelable.swift */; };
+		50F87AF722F5B9220064BEFA /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF322F5B9220064BEFA /* Cancelable.swift */; };
+		50F87AF922F5B9520064BEFA /* Observable+create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF822F5B9520064BEFA /* Observable+create.swift */; };
+		50F87AFA22F5B9520064BEFA /* Observable+create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF822F5B9520064BEFA /* Observable+create.swift */; };
+		50F87AFB22F5B9520064BEFA /* Observable+create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF822F5B9520064BEFA /* Observable+create.swift */; };
+		50F87AFC22F5B9520064BEFA /* Observable+create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AF822F5B9520064BEFA /* Observable+create.swift */; };
+		50F87AFE22F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
+		50F87AFF22F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
+		50F87B0022F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
+		50F87B0122F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -140,6 +176,15 @@
 		3F13C0E81E7B3E4000D8442C /* SwiftLintIntegration.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintIntegration.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F13C0EA1E7B3E4000D8442C /* SwiftLintIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftLintIntegration.swift; sourceTree = "<group>"; };
 		3F13C0EC1E7B3E4000D8442C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		50F87AD322F5B5380064BEFA /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		50F87AD422F5B5610064BEFA /* Select.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Select.swift; sourceTree = "<group>"; };
+		50F87AD922F5B8010064BEFA /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		50F87ADE22F5B82A0064BEFA /* Producer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Producer.swift; sourceTree = "<group>"; };
+		50F87AE322F5B8930064BEFA /* Disposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
+		50F87AE822F5B8AC0064BEFA /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
+		50F87AEE22F5B8E80064BEFA /* Sink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sink.swift; sourceTree = "<group>"; };
+		50F87AF322F5B9220064BEFA /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
+		50F87AF822F5B9520064BEFA /* Observable+create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+create.swift"; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -251,6 +296,30 @@
 			path = SwiftLintIntegration;
 			sourceTree = "<group>";
 		};
+		50F87AED22F5B8D70064BEFA /* Inversion */ = {
+			isa = PBXGroup;
+			children = (
+				50F87AD922F5B8010064BEFA /* Observable.swift */,
+				50F87AF822F5B9520064BEFA /* Observable+create.swift */,
+				50F87AE822F5B8AC0064BEFA /* Observer.swift */,
+				50F87AE322F5B8930064BEFA /* Disposable.swift */,
+				50F87AF322F5B9220064BEFA /* Cancelable.swift */,
+				50F87ADE22F5B82A0064BEFA /* Producer.swift */,
+				50F87AEE22F5B8E80064BEFA /* Sink.swift */,
+				50F87AFD22F5BA7A0064BEFA /* Operators */,
+			);
+			path = Inversion;
+			sourceTree = "<group>";
+		};
+		50F87AFD22F5BA7A0064BEFA /* Operators */ = {
+			isa = PBXGroup;
+			children = (
+				50F87AD422F5B5610064BEFA /* Select.swift */,
+				50F87AD322F5B5380064BEFA /* Filter.swift */,
+			);
+			path = Operators;
+			sourceTree = "<group>";
+		};
 		625E66791C1FF97E0027C288 = {
 			isa = PBXGroup;
 			children = (
@@ -330,6 +399,7 @@
 				625E66BB1C1FFC880027C288 /* StoreSubscriber.swift */,
 				252982ED1C4FD21400281098 /* StoreType.swift */,
 				81BCBECD1C63167A00AA4F03 /* Subscription.swift */,
+				50F87AED22F5B8D70064BEFA /* Inversion */,
 			);
 			path = CoreTypes;
 			sourceTree = "<group>";
@@ -706,15 +776,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF401C30C16000D63A58 /* Action.swift in Sources */,
+				50F87AEC22F5B8AC0064BEFA /* Observer.swift in Sources */,
+				50F87ADD22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF411C30C16000D63A58 /* Store.swift in Sources */,
+				50F87AFC22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF421C30C16000D63A58 /* Reducer.swift in Sources */,
+				50F87AE722F5B8930064BEFA /* Disposable.swift in Sources */,
+				50F87AFE22F5BA870064BEFA /* Filter.swift in Sources */,
 				25DBCF431C30C16000D63A58 /* State.swift in Sources */,
 				252982F11C4FD21400281098 /* StoreType.swift in Sources */,
+				50F87AF222F5B8E80064BEFA /* Sink.swift in Sources */,
+				50F87AD822F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D81D22BC3900D114E8 /* Assertions.swift in Sources */,
 				81BCBED11C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF451C30C16000D63A58 /* StoreSubscriber.swift in Sources */,
+				50F87AF722F5B9220064BEFA /* Cancelable.swift in Sources */,
 				25DBCF461C30C16000D63A58 /* Middleware.swift in Sources */,
 				25DBCF471C30C16000D63A58 /* Coding.swift in Sources */,
+				50F87AE222F5B82A0064BEFA /* Producer.swift in Sources */,
 				D47D2D591E32C4190064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF481C30C16000D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -725,15 +804,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF571C30C19500D63A58 /* Action.swift in Sources */,
+				50F87AEB22F5B8AC0064BEFA /* Observer.swift in Sources */,
+				50F87ADC22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF581C30C19500D63A58 /* Store.swift in Sources */,
+				50F87AFB22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF591C30C19500D63A58 /* Reducer.swift in Sources */,
+				50F87AE622F5B8930064BEFA /* Disposable.swift in Sources */,
+				50F87B0122F5BA870064BEFA /* Filter.swift in Sources */,
 				25DBCF5A1C30C19500D63A58 /* State.swift in Sources */,
 				252982F01C4FD21400281098 /* StoreType.swift in Sources */,
+				50F87AF122F5B8E80064BEFA /* Sink.swift in Sources */,
+				50F87AD722F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D71D22BC3900D114E8 /* Assertions.swift in Sources */,
 				81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF5C1C30C19500D63A58 /* StoreSubscriber.swift in Sources */,
+				50F87AF622F5B9220064BEFA /* Cancelable.swift in Sources */,
 				25DBCF5D1C30C19500D63A58 /* Middleware.swift in Sources */,
 				25DBCF5E1C30C19500D63A58 /* Coding.swift in Sources */,
+				50F87AE122F5B82A0064BEFA /* Producer.swift in Sources */,
 				D47D2D581E32C4180064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF5F1C30C19500D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -761,15 +849,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				25DBCF931C30C4F000D63A58 /* Action.swift in Sources */,
+				50F87AEA22F5B8AC0064BEFA /* Observer.swift in Sources */,
+				50F87ADB22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF941C30C4F000D63A58 /* Store.swift in Sources */,
+				50F87AFA22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF951C30C4F000D63A58 /* Reducer.swift in Sources */,
+				50F87AE522F5B8930064BEFA /* Disposable.swift in Sources */,
+				50F87AFF22F5BA870064BEFA /* Filter.swift in Sources */,
 				25DBCF961C30C4F000D63A58 /* State.swift in Sources */,
 				252982EF1C4FD21400281098 /* StoreType.swift in Sources */,
+				50F87AF022F5B8E80064BEFA /* Sink.swift in Sources */,
+				50F87AD622F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D61D22BC3900D114E8 /* Assertions.swift in Sources */,
 				81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF981C30C4F000D63A58 /* StoreSubscriber.swift in Sources */,
+				50F87AF522F5B9220064BEFA /* Cancelable.swift in Sources */,
 				25DBCF991C30C4F000D63A58 /* Middleware.swift in Sources */,
 				25DBCF9A1C30C4F000D63A58 /* Coding.swift in Sources */,
+				50F87AE022F5B82A0064BEFA /* Producer.swift in Sources */,
 				D47D2D571E32C4170064769E /* DispatchingStoreType.swift in Sources */,
 				25DBCF9B1C30C4F000D63A58 /* TypeHelper.swift in Sources */,
 			);
@@ -805,15 +902,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				625E66C11C1FFC880027C288 /* StoreSubscriber.swift in Sources */,
+				50F87AE922F5B8AC0064BEFA /* Observer.swift in Sources */,
+				50F87ADA22F5B8010064BEFA /* Observable.swift in Sources */,
 				625E66BD1C1FFC880027C288 /* Store.swift in Sources */,
+				50F87AF922F5B9520064BEFA /* Observable+create.swift in Sources */,
 				625E66B31C1FFC830027C288 /* Coding.swift in Sources */,
+				50F87AE422F5B8930064BEFA /* Disposable.swift in Sources */,
+				50F87B0022F5BA870064BEFA /* Filter.swift in Sources */,
 				625E66BC1C1FFC880027C288 /* Action.swift in Sources */,
 				259737FD1C2C661100869B8F /* Middleware.swift in Sources */,
+				50F87AEF22F5B8E80064BEFA /* Sink.swift in Sources */,
+				50F87AD522F5B5610064BEFA /* Select.swift in Sources */,
 				252982EE1C4FD21400281098 /* StoreType.swift in Sources */,
 				73E545D51D22BC3900D114E8 /* Assertions.swift in Sources */,
 				81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */,
+				50F87AF422F5B9220064BEFA /* Cancelable.swift in Sources */,
 				625E66BE1C1FFC880027C288 /* Reducer.swift in Sources */,
 				625E66B41C1FFC830027C288 /* TypeHelper.swift in Sources */,
+				50F87ADF22F5B82A0064BEFA /* Producer.swift in Sources */,
 				D47D2D561E32C3F50064769E /* DispatchingStoreType.swift in Sources */,
 				625E66BF1C1FFC880027C288 /* State.swift in Sources */,
 			);

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -89,6 +89,10 @@
 		50F87AFF22F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
 		50F87B0022F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
 		50F87B0122F5BA870064BEFA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87AD322F5B5380064BEFA /* Filter.swift */; };
+		50F87B1222F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
+		50F87B1322F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
+		50F87B1422F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
+		50F87B1522F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -185,6 +189,7 @@
 		50F87AEE22F5B8E80064BEFA /* Sink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sink.swift; sourceTree = "<group>"; };
 		50F87AF322F5B9220064BEFA /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		50F87AF822F5B9520064BEFA /* Observable+create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+create.swift"; sourceTree = "<group>"; };
+		50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscription.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -299,6 +304,7 @@
 		50F87AED22F5B8D70064BEFA /* Inversion */ = {
 			isa = PBXGroup;
 			children = (
+				50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */,
 				50F87AD922F5B8010064BEFA /* Observable.swift */,
 				50F87AF822F5B9520064BEFA /* Observable+create.swift */,
 				50F87AE822F5B8AC0064BEFA /* Observer.swift */,
@@ -783,6 +789,7 @@
 				25DBCF421C30C16000D63A58 /* Reducer.swift in Sources */,
 				50F87AE722F5B8930064BEFA /* Disposable.swift in Sources */,
 				50F87AFE22F5BA870064BEFA /* Filter.swift in Sources */,
+				50F87B1522F6E3120064BEFA /* IncompleteSubscription.swift in Sources */,
 				25DBCF431C30C16000D63A58 /* State.swift in Sources */,
 				252982F11C4FD21400281098 /* StoreType.swift in Sources */,
 				50F87AF222F5B8E80064BEFA /* Sink.swift in Sources */,
@@ -811,6 +818,7 @@
 				25DBCF591C30C19500D63A58 /* Reducer.swift in Sources */,
 				50F87AE622F5B8930064BEFA /* Disposable.swift in Sources */,
 				50F87B0122F5BA870064BEFA /* Filter.swift in Sources */,
+				50F87B1422F6E3120064BEFA /* IncompleteSubscription.swift in Sources */,
 				25DBCF5A1C30C19500D63A58 /* State.swift in Sources */,
 				252982F01C4FD21400281098 /* StoreType.swift in Sources */,
 				50F87AF122F5B8E80064BEFA /* Sink.swift in Sources */,
@@ -856,6 +864,7 @@
 				25DBCF951C30C4F000D63A58 /* Reducer.swift in Sources */,
 				50F87AE522F5B8930064BEFA /* Disposable.swift in Sources */,
 				50F87AFF22F5BA870064BEFA /* Filter.swift in Sources */,
+				50F87B1322F6E3120064BEFA /* IncompleteSubscription.swift in Sources */,
 				25DBCF961C30C4F000D63A58 /* State.swift in Sources */,
 				252982EF1C4FD21400281098 /* StoreType.swift in Sources */,
 				50F87AF022F5B8E80064BEFA /* Sink.swift in Sources */,
@@ -909,6 +918,7 @@
 				625E66B31C1FFC830027C288 /* Coding.swift in Sources */,
 				50F87AE422F5B8930064BEFA /* Disposable.swift in Sources */,
 				50F87B0022F5BA870064BEFA /* Filter.swift in Sources */,
+				50F87B1222F6E3120064BEFA /* IncompleteSubscription.swift in Sources */,
 				625E66BC1C1FFC880027C288 /* Action.swift in Sources */,
 				259737FD1C2C661100869B8F /* Middleware.swift in Sources */,
 				50F87AEF22F5B8E80064BEFA /* Sink.swift in Sources */,

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -106,6 +106,12 @@
 		50F87B2422F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
 		50F87B2522F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
 		50F87B2622F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
+		50F87B2822F841780064BEFA /* ObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2722F841780064BEFA /* ObservableTests.swift */; };
+		50F87B2922F841780064BEFA /* ObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2722F841780064BEFA /* ObservableTests.swift */; };
+		50F87B2A22F841780064BEFA /* ObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2722F841780064BEFA /* ObservableTests.swift */; };
+		50F87B2C22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
+		50F87B2D22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
+		50F87B2E22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -207,6 +213,8 @@
 		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
 		50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionToken.swift; sourceTree = "<group>"; };
 		50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockSubscriberTests.swift; sourceTree = "<group>"; };
+		50F87B2722F841780064BEFA /* ObservableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableTests.swift; sourceTree = "<group>"; };
+		50F87B2B22F841980064BEFA /* ObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverTests.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -394,6 +402,8 @@
 				73F39F371D3EE46A00DFFE62 /* StoreSubscriptionTests.swift */,
 				50F87B1A22F823110064BEFA /* DisposableTests.swift */,
 				50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */,
+				50F87B2722F841780064BEFA /* ObservableTests.swift */,
+				50F87B2B22F841980064BEFA /* ObserverTests.swift */,
 				625E66A61C1FFA640027C288 /* StoreTests.swift */,
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
@@ -864,12 +874,14 @@
 			files = (
 				50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */,
 				50F87B1922F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
+				50F87B2E22F841980064BEFA /* ObserverTests.swift in Sources */,
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
 				73F39F361D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				50F87B2622F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 				25AB3B831C54A84700A41513 /* StoreSubscriberTests.swift in Sources */,
 				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DC1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
+				50F87B2A22F841780064BEFA /* ObservableTests.swift in Sources */,
 				73723E061D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F3A1D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF741C30C34000D63A58 /* TypeHelperTests.swift in Sources */,
@@ -914,12 +926,14 @@
 			files = (
 				50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */,
 				50F87B1822F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
+				50F87B2D22F841980064BEFA /* ObserverTests.swift in Sources */,
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
 				73F39F351D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				50F87B2522F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 				25AB3B821C54A84600A41513 /* StoreSubscriberTests.swift in Sources */,
 				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DB1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
+				50F87B2922F841780064BEFA /* ObservableTests.swift in Sources */,
 				73723E051D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F391D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				25DBCF9F1C30C50000D63A58 /* TypeHelperTests.swift in Sources */,
@@ -979,10 +993,12 @@
 				73723E041D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F381D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				50F87B1722F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
+				50F87B2C22F841980064BEFA /* ObserverTests.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,
 				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,
 				50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */,
 				759801931FB16D2D006EDE17 /* AutomaticallySkipRepeatsTests.swift in Sources */,
+				50F87B2822F841780064BEFA /* ObservableTests.swift in Sources */,
 				50F87B2422F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -96,6 +96,9 @@
 		50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1722F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
+		50F87B1822F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
+		50F87B1922F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -194,6 +197,7 @@
 		50F87AF822F5B9520064BEFA /* Observable+create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+create.swift"; sourceTree = "<group>"; };
 		50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscription.swift; sourceTree = "<group>"; };
 		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
+		50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscriptionTests.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -378,6 +382,7 @@
 				25AB3B7F1C54A79F00A41513 /* StoreSubscriberTests.swift */,
 				73F39F371D3EE46A00DFFE62 /* StoreSubscriptionTests.swift */,
 				50F87B1A22F823110064BEFA /* DisposableTests.swift */,
+				50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */,
 				625E66A61C1FFA640027C288 /* StoreTests.swift */,
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
@@ -845,6 +850,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */,
+				50F87B1922F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
 				73F39F361D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				25AB3B831C54A84700A41513 /* StoreSubscriberTests.swift in Sources */,
@@ -892,6 +898,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */,
+				50F87B1822F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
 				73F39F351D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				25AB3B821C54A84600A41513 /* StoreSubscriberTests.swift in Sources */,
@@ -954,6 +961,7 @@
 				73E545DA1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
 				73723E041D30AEF3006139F0 /* XCTest+Compatibility.swift in Sources */,
 				73F39F381D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
+				50F87B1722F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,
 				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,
 				50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */,

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -99,6 +99,10 @@
 		50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1F22F832FF0064BEFA /* SubscriptionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */; };
+		50F87B2022F832FF0064BEFA /* SubscriptionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */; };
+		50F87B2122F832FF0064BEFA /* SubscriptionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */; };
+		50F87B2222F832FF0064BEFA /* SubscriptionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */; };
 		50F87B2422F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
 		50F87B2522F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
 		50F87B2622F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
@@ -201,6 +205,7 @@
 		50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscription.swift; sourceTree = "<group>"; };
 		50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscriptionTests.swift; sourceTree = "<group>"; };
 		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
+		50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionToken.swift; sourceTree = "<group>"; };
 		50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockSubscriberTests.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
@@ -317,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */,
+				50F87B1E22F832FF0064BEFA /* SubscriptionToken.swift */,
 				50F87AD922F5B8010064BEFA /* Observable.swift */,
 				50F87AF822F5B9520064BEFA /* Observable+create.swift */,
 				50F87AE822F5B8AC0064BEFA /* Observer.swift */,
@@ -800,6 +806,7 @@
 				50F87AEC22F5B8AC0064BEFA /* Observer.swift in Sources */,
 				50F87ADD22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF411C30C16000D63A58 /* Store.swift in Sources */,
+				50F87B2222F832FF0064BEFA /* SubscriptionToken.swift in Sources */,
 				50F87AFC22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF421C30C16000D63A58 /* Reducer.swift in Sources */,
 				50F87AE722F5B8930064BEFA /* Disposable.swift in Sources */,
@@ -829,6 +836,7 @@
 				50F87AEB22F5B8AC0064BEFA /* Observer.swift in Sources */,
 				50F87ADC22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF581C30C19500D63A58 /* Store.swift in Sources */,
+				50F87B2122F832FF0064BEFA /* SubscriptionToken.swift in Sources */,
 				50F87AFB22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF591C30C19500D63A58 /* Reducer.swift in Sources */,
 				50F87AE622F5B8930064BEFA /* Disposable.swift in Sources */,
@@ -878,6 +886,7 @@
 				50F87AEA22F5B8AC0064BEFA /* Observer.swift in Sources */,
 				50F87ADB22F5B8010064BEFA /* Observable.swift in Sources */,
 				25DBCF941C30C4F000D63A58 /* Store.swift in Sources */,
+				50F87B2022F832FF0064BEFA /* SubscriptionToken.swift in Sources */,
 				50F87AFA22F5B9520064BEFA /* Observable+create.swift in Sources */,
 				25DBCF951C30C4F000D63A58 /* Reducer.swift in Sources */,
 				50F87AE522F5B8930064BEFA /* Disposable.swift in Sources */,
@@ -935,6 +944,7 @@
 				50F87AE922F5B8AC0064BEFA /* Observer.swift in Sources */,
 				50F87ADA22F5B8010064BEFA /* Observable.swift in Sources */,
 				625E66BD1C1FFC880027C288 /* Store.swift in Sources */,
+				50F87B1F22F832FF0064BEFA /* SubscriptionToken.swift in Sources */,
 				50F87AF922F5B9520064BEFA /* Observable+create.swift in Sources */,
 				625E66B31C1FFC830027C288 /* Coding.swift in Sources */,
 				50F87AE422F5B8930064BEFA /* Disposable.swift in Sources */,

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -93,12 +93,15 @@
 		50F87B1322F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
 		50F87B1422F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
 		50F87B1522F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
-		50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
-		50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
-		50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		50F87B1722F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
 		50F87B1822F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
 		50F87B1922F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */; };
+		50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B2422F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
+		50F87B2522F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
+		50F87B2622F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -196,8 +199,9 @@
 		50F87AF322F5B9220064BEFA /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		50F87AF822F5B9520064BEFA /* Observable+create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+create.swift"; sourceTree = "<group>"; };
 		50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscription.swift; sourceTree = "<group>"; };
-		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
 		50F87B1622F80D3E0064BEFA /* IncompleteSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscriptionTests.swift; sourceTree = "<group>"; };
+		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
+		50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockSubscriberTests.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -377,6 +381,7 @@
 			children = (
 				625E669E1C1FFA3C0027C288 /* Info.plist */,
 				D490BC41203F27E000902589 /* PerformanceTests.swift */,
+				50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */,
 				73F39F331D3EE3C300DFFE62 /* StoreDispatchTests.swift */,
 				259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */,
 				25AB3B7F1C54A79F00A41513 /* StoreSubscriberTests.swift */,
@@ -853,6 +858,7 @@
 				50F87B1922F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
 				73F39F361D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
+				50F87B2622F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 				25AB3B831C54A84700A41513 /* StoreSubscriberTests.swift in Sources */,
 				25DBCF721C30C34000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DC1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
@@ -901,6 +907,7 @@
 				50F87B1822F80D3E0064BEFA /* IncompleteSubscriptionTests.swift in Sources */,
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
 				73F39F351D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
+				50F87B2522F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 				25AB3B821C54A84600A41513 /* StoreSubscriberTests.swift in Sources */,
 				25DBCF9D1C30C50000D63A58 /* StoreMiddlewareTests.swift in Sources */,
 				73E545DB1D22BCD600D114E8 /* XCTest+Assertions.swift in Sources */,
@@ -966,6 +973,7 @@
 				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,
 				50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */,
 				759801931FB16D2D006EDE17 /* AutomaticallySkipRepeatsTests.swift in Sources */,
+				50F87B2422F8350E0064BEFA /* BlockSubscriberTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -112,6 +112,10 @@
 		50F87B2C22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
 		50F87B2D22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
 		50F87B2E22F841980064BEFA /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B2B22F841980064BEFA /* ObserverTests.swift */; };
+		50F87BB422F89ECB0064BEFA /* SkipRepeats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */; };
+		50F87BB522F89ECB0064BEFA /* SkipRepeats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */; };
+		50F87BB622F89ECB0064BEFA /* SkipRepeats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */; };
+		50F87BB722F89ECB0064BEFA /* SkipRepeats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -215,6 +219,7 @@
 		50F87B2322F8350E0064BEFA /* BlockSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockSubscriberTests.swift; sourceTree = "<group>"; };
 		50F87B2722F841780064BEFA /* ObservableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableTests.swift; sourceTree = "<group>"; };
 		50F87B2B22F841980064BEFA /* ObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverTests.swift; sourceTree = "<group>"; };
+		50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipRepeats.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -348,6 +353,7 @@
 			children = (
 				50F87AD422F5B5610064BEFA /* Select.swift */,
 				50F87AD322F5B5380064BEFA /* Filter.swift */,
+				50F87BB322F89ECB0064BEFA /* SkipRepeats.swift */,
 			);
 			path = Operators;
 			sourceTree = "<group>";
@@ -827,6 +833,7 @@
 				50F87AF222F5B8E80064BEFA /* Sink.swift in Sources */,
 				50F87AD822F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D81D22BC3900D114E8 /* Assertions.swift in Sources */,
+				50F87BB722F89ECB0064BEFA /* SkipRepeats.swift in Sources */,
 				81BCBED11C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF451C30C16000D63A58 /* StoreSubscriber.swift in Sources */,
 				50F87AF722F5B9220064BEFA /* Cancelable.swift in Sources */,
@@ -857,6 +864,7 @@
 				50F87AF122F5B8E80064BEFA /* Sink.swift in Sources */,
 				50F87AD722F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D71D22BC3900D114E8 /* Assertions.swift in Sources */,
+				50F87BB622F89ECB0064BEFA /* SkipRepeats.swift in Sources */,
 				81BCBED01C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF5C1C30C19500D63A58 /* StoreSubscriber.swift in Sources */,
 				50F87AF622F5B9220064BEFA /* Cancelable.swift in Sources */,
@@ -909,6 +917,7 @@
 				50F87AF022F5B8E80064BEFA /* Sink.swift in Sources */,
 				50F87AD622F5B5610064BEFA /* Select.swift in Sources */,
 				73E545D61D22BC3900D114E8 /* Assertions.swift in Sources */,
+				50F87BB522F89ECB0064BEFA /* SkipRepeats.swift in Sources */,
 				81BCBECF1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				25DBCF981C30C4F000D63A58 /* StoreSubscriber.swift in Sources */,
 				50F87AF522F5B9220064BEFA /* Cancelable.swift in Sources */,
@@ -969,6 +978,7 @@
 				50F87AEF22F5B8E80064BEFA /* Sink.swift in Sources */,
 				50F87AD522F5B5610064BEFA /* Select.swift in Sources */,
 				252982EE1C4FD21400281098 /* StoreType.swift in Sources */,
+				50F87BB422F89ECB0064BEFA /* SkipRepeats.swift in Sources */,
 				73E545D51D22BC3900D114E8 /* Assertions.swift in Sources */,
 				81BCBECE1C63167A00AA4F03 /* Subscription.swift in Sources */,
 				50F87AF422F5B9220064BEFA /* Cancelable.swift in Sources */,

--- a/ReSwift.xcodeproj/project.pbxproj
+++ b/ReSwift.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		50F87B1322F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
 		50F87B1422F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
 		50F87B1522F6E3120064BEFA /* IncompleteSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */; };
+		50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
+		50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F87B1A22F823110064BEFA /* DisposableTests.swift */; };
 		621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621C068B1C278BEF008029AE /* TypeHelperTests.swift */; };
 		625E66871C1FF97E0027C288 /* ReSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 625E66861C1FF97E0027C288 /* ReSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		625E669F1C1FFA3C0027C288 /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 625E66831C1FF97E0027C288 /* ReSwift.framework */; };
@@ -190,6 +193,7 @@
 		50F87AF322F5B9220064BEFA /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		50F87AF822F5B9520064BEFA /* Observable+create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+create.swift"; sourceTree = "<group>"; };
 		50F87B1122F6E3120064BEFA /* IncompleteSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncompleteSubscription.swift; sourceTree = "<group>"; };
+		50F87B1A22F823110064BEFA /* DisposableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposableTests.swift; sourceTree = "<group>"; };
 		5FA6CE811A62136B33F7E836 /* Pods-SwiftLintIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftLintIntegration.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftLintIntegration/Pods-SwiftLintIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		621C068B1C278BEF008029AE /* TypeHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeHelperTests.swift; sourceTree = "<group>"; };
 		625E66831C1FF97E0027C288 /* ReSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -373,6 +377,7 @@
 				259737E91C2C611600869B8F /* StoreMiddlewareTests.swift */,
 				25AB3B7F1C54A79F00A41513 /* StoreSubscriberTests.swift */,
 				73F39F371D3EE46A00DFFE62 /* StoreSubscriptionTests.swift */,
+				50F87B1A22F823110064BEFA /* DisposableTests.swift */,
 				625E66A61C1FFA640027C288 /* StoreTests.swift */,
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
 				621C068B1C278BEF008029AE /* TypeHelperTests.swift */,
@@ -839,6 +844,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50F87B1D22F823110064BEFA /* DisposableTests.swift in Sources */,
 				25DBCF711C30C34000D63A58 /* StoreTests.swift in Sources */,
 				73F39F361D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				25AB3B831C54A84700A41513 /* StoreSubscriberTests.swift in Sources */,
@@ -885,6 +891,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50F87B1C22F823110064BEFA /* DisposableTests.swift in Sources */,
 				25DBCF9C1C30C50000D63A58 /* StoreTests.swift in Sources */,
 				73F39F351D3EE3C300DFFE62 /* StoreDispatchTests.swift in Sources */,
 				25AB3B821C54A84600A41513 /* StoreSubscriberTests.swift in Sources */,
@@ -949,6 +956,7 @@
 				73F39F381D3EE46A00DFFE62 /* StoreSubscriptionTests.swift in Sources */,
 				621C068C1C278BEF008029AE /* TypeHelperTests.swift in Sources */,
 				259737EA1C2C611600869B8F /* StoreMiddlewareTests.swift in Sources */,
+				50F87B1B22F823110064BEFA /* DisposableTests.swift in Sources */,
 				759801931FB16D2D006EDE17 /* AutomaticallySkipRepeatsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReSwift/CoreTypes/Inversion/Cancelable.swift
+++ b/ReSwift/CoreTypes/Inversion/Cancelable.swift
@@ -1,0 +1,12 @@
+//
+//  Cancelable.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// Intended for side-effects.
+protocol Cancelable: Disposable {
+    var isDisposed: Bool { get }
+}

--- a/ReSwift/CoreTypes/Inversion/Disposable.swift
+++ b/ReSwift/CoreTypes/Inversion/Disposable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
-public protocol Disposable {
+internal protocol Disposable {
     /// Dispose resource callback.
     func dispose()
 }

--- a/ReSwift/CoreTypes/Inversion/Disposable.swift
+++ b/ReSwift/CoreTypes/Inversion/Disposable.swift
@@ -16,12 +16,32 @@ func createDisposable() -> Disposable {
     return NullDisposable.noOp
 }
 
-private struct NullDisposable : Disposable {
+func createDisposable(with action: @escaping () -> Void) -> Disposable {
+    return AnonymousDisposable(action: action)
+}
+
+private struct NullDisposable: Disposable {
     fileprivate static let noOp: Disposable = NullDisposable()
 
-    private init() {}
+    init() {}
 
-    public func dispose() {
+    func dispose() {
         // no-op
+    }
+}
+
+private final class AnonymousDisposable: Disposable {
+    public typealias DisposeAction = () -> Void
+
+    private var disposeAction: DisposeAction?
+
+    init(action: @escaping DisposeAction) {
+        self.disposeAction = action
+    }
+
+    func dispose() {
+        guard let action = self.disposeAction else { return }
+        self.disposeAction = nil
+        action()
     }
 }

--- a/ReSwift/CoreTypes/Inversion/Disposable.swift
+++ b/ReSwift/CoreTypes/Inversion/Disposable.swift
@@ -1,0 +1,27 @@
+//
+//  Disposable.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+public protocol Disposable {
+    /// Dispose resource callback.
+    func dispose()
+}
+
+/// Create disposable that does nothing when cleaning up resources.
+func createDisposable() -> Disposable {
+    return NullDisposable.noOp
+}
+
+private struct NullDisposable : Disposable {
+    fileprivate static let noOp: Disposable = NullDisposable()
+
+    private init() {}
+
+    public func dispose() {
+        // no-op
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
+++ b/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
@@ -52,29 +52,3 @@ public final class IncompleteSubscription<RootStoreState: StateType, Substate> {
         self.store.subscribe(bridge)
     }
 }
-
-extension IncompleteSubscription {
-    public func select<SelectedSubstate>(_ transform: @escaping (Substate) -> SelectedSubstate) -> IncompleteSubscription<RootStoreState, SelectedSubstate> {
-        return IncompleteSubscription<RootStoreState, SelectedSubstate>(
-            store: self.store,
-            observable: self.observable.select(transform))
-    }
-
-    public func filter(_ predicate: @escaping (Substate) -> Bool) -> IncompleteSubscription<RootStoreState, Substate> {
-        return IncompleteSubscription<RootStoreState, Substate>(
-            store: self.store,
-            observable: self.observable.filter(predicate))
-    }
-}
-
-private final class Bridge<RootStoreState: StateType, Substate>: StoreSubscriber {
-    private let base: AnyStoreSubscriber
-
-    init<Subscriber: StoreSubscriber>(subscriber: Subscriber) where Subscriber.StoreSubscriberStateType == Substate {
-        self.base = subscriber
-    }
-
-    func newState(state: RootStoreState) {
-        self.base._newState(state: state)
-    }
-}

--- a/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
+++ b/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
@@ -1,0 +1,79 @@
+//
+//  IncompleteSubscription.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-04.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+class BlockSubscription<Substate>: StoreSubscriber {
+    let callback: (Substate) -> Void
+
+    init(callback: @escaping (Substate) -> Void) {
+        self.callback = callback
+    }
+
+    func newState(state: Substate) {
+        self.callback(state)
+    }
+}
+
+extension Store {
+    func asObservable() -> Observable<State> {
+        return Observable.create { [weak self] observer -> Disposable in
+            let subscription = BlockSubscription(callback: { (state: State) in
+                observer.on(state)
+            })
+
+            self?.subscribe(subscription)
+
+            return createDisposable {
+                self?.unsubscribe(subscription)
+            }
+        }
+    }
+}
+
+public final class IncompleteSubscription<RootStoreState: StateType, Substate> {
+    typealias CompatibleStore = Store<RootStoreState>
+
+    internal let store: CompatibleStore
+    internal let observable: Observable<Substate>
+
+    /// Used during transformations.
+    internal init(store: CompatibleStore, observable: Observable<Substate>) {
+        self.store = store
+        self.observable = observable
+    }
+
+    public func subscribe<Subscriber: StoreSubscriber>(_ subscriber: Subscriber) where Subscriber.StoreSubscriberStateType == Substate {
+        let bridge = Bridge<RootStoreState, Substate>(subscriber: subscriber)
+        self.store.subscribe(bridge)
+    }
+}
+
+extension IncompleteSubscription {
+    public func select<SelectedSubstate>(_ transform: @escaping (Substate) -> SelectedSubstate) -> IncompleteSubscription<RootStoreState, SelectedSubstate> {
+        return IncompleteSubscription<RootStoreState, SelectedSubstate>(
+            store: self.store,
+            observable: self.observable.select(transform))
+    }
+
+    public func filter(_ predicate: @escaping (Substate) -> Bool) -> IncompleteSubscription<RootStoreState, Substate> {
+        return IncompleteSubscription<RootStoreState, Substate>(
+            store: self.store,
+            observable: self.observable.filter(predicate))
+    }
+}
+
+private final class Bridge<RootStoreState: StateType, Substate>: StoreSubscriber {
+    private let base: AnyStoreSubscriber
+
+    init<Subscriber: StoreSubscriber>(subscriber: Subscriber) where Subscriber.StoreSubscriberStateType == Substate {
+        self.base = subscriber
+    }
+
+    func newState(state: RootStoreState) {
+        self.base._newState(state: state)
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
+++ b/ReSwift/CoreTypes/Inversion/IncompleteSubscription.swift
@@ -6,24 +6,25 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
-class BlockSubscription<Substate>: StoreSubscriber {
-    let callback: (Substate) -> Void
+internal final class BlockSubscriber<S>: StoreSubscriber {
+    typealias StoreSubscriberStateType = S
+    private let block: (S) -> Void
 
-    init(callback: @escaping (Substate) -> Void) {
-        self.callback = callback
+    init(block: @escaping (S) -> Void) {
+        self.block = block
     }
 
-    func newState(state: Substate) {
-        self.callback(state)
+    func newState(state: S) {
+        self.block(state)
     }
 }
 
 extension Store {
     func asObservable() -> Observable<State> {
         return Observable.create { [weak self] observer -> Disposable in
-            let subscription = BlockSubscription(callback: { (state: State) in
+            let subscription = BlockSubscriber { (state: State) in
                 observer.on(state)
-            })
+            }
 
             self?.subscribe(subscription)
 

--- a/ReSwift/CoreTypes/Inversion/Observable+create.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable+create.swift
@@ -8,13 +8,13 @@
 
 extension Observable {
     /// Starting point of events, aka state updates.
-    internal static func create(_ subscribe: @escaping (AnyObserver<Element>) -> Disposable) -> Observable<Element> {
+    internal static func create(_ subscribe: @escaping (AnyObserver<Substate>) -> Disposable) -> Observable<Substate> {
         return AnonymousObservable(subscribe)
     }
 }
 
-final private class AnonymousObservable<Element>: Producer<Element> {
-    typealias Handler = (AnyObserver<Element>) -> Disposable
+final private class AnonymousObservable<Substate>: Producer<Substate> {
+    typealias Handler = (AnyObserver<Substate>) -> Disposable
 
     let handler: Handler
 
@@ -22,7 +22,7 @@ final private class AnonymousObservable<Element>: Producer<Element> {
         self.handler = handler
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Substate == Substate {
         let sink = AnonymousObservableSink(observer: observer, cancel: cancel)
         let subscription = sink.run(self)
         return (sink, subscription)
@@ -30,14 +30,14 @@ final private class AnonymousObservable<Element>: Producer<Element> {
 }
 
 final private class AnonymousObservableSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
-    typealias Element = Observer.Element
-    typealias Parent = AnonymousObservable<Element>
+    typealias Substate = Observer.Substate
+    typealias Parent = AnonymousObservable<Substate>
 
     override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
 
-    func on(_ state: Element) {
+    func on(_ state: Substate) {
         self.observer.on(state)
     }
 

--- a/ReSwift/CoreTypes/Inversion/Observable+create.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable+create.swift
@@ -32,7 +32,12 @@ final private class ObservableEventSource<Substate>: Producer<Substate> {
         self.producer = producer
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Substate == Substate {
+    override func run<Observer: ObserverType>(
+        _ observer: Observer,
+        cancel: Cancelable
+        ) -> (sink: Disposable, subscription: Disposable)
+        where Observer.Substate == Substate
+    {
         let sink = ObservableEventSourceSink(observer: observer, cancel: cancel)
         let subscription = sink.subscribeObserver(self)
         return (sink, subscription)

--- a/ReSwift/CoreTypes/Inversion/Observable+create.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable+create.swift
@@ -1,0 +1,47 @@
+//
+//  Observable+create.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+extension Observable {
+    /// Starting point of events, aka state updates.
+    internal static func create(_ subscribe: @escaping (AnyObserver<Element>) -> Disposable) -> Observable<Element> {
+        return AnonymousObservable(subscribe)
+    }
+}
+
+final private class AnonymousObservable<Element>: Producer<Element> {
+    typealias Handler = (AnyObserver<Element>) -> Disposable
+
+    let handler: Handler
+
+    init(_ handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+        let sink = AnonymousObservableSink(observer: observer, cancel: cancel)
+        let subscription = sink.run(self)
+        return (sink, subscription)
+    }
+}
+
+final private class AnonymousObservableSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element
+    typealias Parent = AnonymousObservable<Element>
+
+    override init(observer: Observer, cancel: Cancelable) {
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ state: Element) {
+        self.observer.on(state)
+    }
+
+    func run(_ parent: Parent) -> Disposable {
+        return parent.handler(AnyObserver(self))
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Observable.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable.swift
@@ -13,8 +13,8 @@ protocol ObservableType {
 }
 
 extension ObservableType {
-    func subscribe(_ actionHandler: @escaping (Action) -> Void) -> Disposable {
-        let observer = AnyObserver(actionHandler: actionHandler)
+    func subscribe(_ observer: @escaping (Substate) -> Void) -> Disposable {
+        let observer = AnyObserver(observer: observer)
         return self.asObservable().subscribe(observer)
     }
 }
@@ -35,7 +35,7 @@ internal class Observable<Substate>: ObservableType {
         // no-op
     }
 
-    func subscribe<Observer>(_ observer: Observer) -> Disposable {
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Substate == Substate {
         fatalError("Method not implemented: \(#function)")
     }
 

--- a/ReSwift/CoreTypes/Inversion/Observable.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable.swift
@@ -30,12 +30,12 @@ extension ObservableType {
 /// Type-erased `ObervableType`.
 ///
 /// You can only get `Observable` instances through the `create` static factory, as used by the `Store`.
-open class Observable<Substate>: ObservableType {
+internal class Observable<Substate>: ObservableType {
     internal init() {
         // no-op
     }
 
-    public func subscribe<Observer>(_ observer: Observer) -> Disposable {
+    func subscribe<Observer>(_ observer: Observer) -> Disposable {
         fatalError("Method not implemented: \(#function)")
     }
 
@@ -44,7 +44,7 @@ open class Observable<Substate>: ObservableType {
         return ReSwift.select(source: self, transform: transform)
     }
 
-    public func asObservable() -> Observable<Substate> {
+    func asObservable() -> Observable<Substate> {
         return self
     }
 }

--- a/ReSwift/CoreTypes/Inversion/Observable.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable.swift
@@ -40,7 +40,10 @@ internal class Observable<Substate>: ObservableType {
     }
 
     /// Optimization hook for multiple `select` calls in succession. Is overwritten by the `Select` type.
-    internal func composeSelect<SelectedSubstate>(_ transform: @escaping (Substate) -> SelectedSubstate) -> Observable<SelectedSubstate> {
+    internal func composeSelect<SelectedSubstate>(
+        _ transform: @escaping (Substate) -> SelectedSubstate
+        ) -> Observable<SelectedSubstate>
+    {
         return ReSwift.select(source: self, transform: transform)
     }
 

--- a/ReSwift/CoreTypes/Inversion/Observable.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable.swift
@@ -8,8 +8,8 @@
 
 /// Represents a push style state update sequence.
 protocol ObservableType {
-    associatedtype Element
-    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element
+    associatedtype Substate
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Substate == Substate
 }
 
 extension ObservableType {
@@ -20,7 +20,7 @@ extension ObservableType {
 }
 
 extension ObservableType {
-    func asObservable() -> Observable<Element> {
+    func asObservable() -> Observable<Substate> {
         return Observable.create { observer in
             return self.subscribe(observer)
         }
@@ -30,7 +30,7 @@ extension ObservableType {
 /// Type-erased `ObervableType`.
 ///
 /// You can only get `Observable` instances through the `create` static factory, as used by the `Store`.
-open class Observable<Element>: ObservableType {
+open class Observable<Substate>: ObservableType {
     internal init() {
         // no-op
     }
@@ -40,11 +40,11 @@ open class Observable<Element>: ObservableType {
     }
 
     /// Optimization hook for multiple `select` calls in succession. Is overwritten by the `Select` type.
-    internal func composeMap<Substate>(_ transform: @escaping (Element) -> Substate) -> Observable<Substate> {
+    internal func composeSelect<SelectedSubstate>(_ transform: @escaping (Substate) -> SelectedSubstate) -> Observable<SelectedSubstate> {
         return ReSwift.select(source: self, transform: transform)
     }
 
-    public func asObservable() -> Observable<Element> {
+    public func asObservable() -> Observable<Substate> {
         return self
     }
 }

--- a/ReSwift/CoreTypes/Inversion/Observable.swift
+++ b/ReSwift/CoreTypes/Inversion/Observable.swift
@@ -1,0 +1,50 @@
+//
+//  Observable.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// Represents a push style state update sequence.
+protocol ObservableType {
+    associatedtype Element
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element
+}
+
+extension ObservableType {
+    func subscribe(_ actionHandler: @escaping (Action) -> Void) -> Disposable {
+        let observer = AnyObserver(actionHandler: actionHandler)
+        return self.asObservable().subscribe(observer)
+    }
+}
+
+extension ObservableType {
+    func asObservable() -> Observable<Element> {
+        return Observable.create { observer in
+            return self.subscribe(observer)
+        }
+    }
+}
+
+/// Type-erased `ObervableType`.
+///
+/// You can only get `Observable` instances through the `create` static factory, as used by the `Store`.
+open class Observable<Element>: ObservableType {
+    internal init() {
+        // no-op
+    }
+
+    public func subscribe<Observer>(_ observer: Observer) -> Disposable {
+        fatalError("Method not implemented: \(#function)")
+    }
+
+    /// Optimization hook for multiple `select` calls in succession. Is overwritten by the `Select` type.
+    internal func composeMap<Substate>(_ transform: @escaping (Element) -> Substate) -> Observable<Substate> {
+        return ReSwift.select(source: self, transform: transform)
+    }
+
+    public func asObservable() -> Observable<Element> {
+        return self
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Observer.swift
+++ b/ReSwift/CoreTypes/Inversion/Observer.swift
@@ -1,0 +1,30 @@
+//
+//  Observer.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// Receives a state update.
+protocol ObserverType {
+    associatedtype Element
+    func on(_ state: Element)
+}
+
+
+internal struct AnyObserver<Substate>: ObserverType {
+    private let actionHandler: (Substate) -> Void
+
+    init(actionHandler: @escaping (Substate) -> Void) {
+        self.actionHandler = actionHandler
+    }
+
+    init<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Substate {
+        self.actionHandler = observer.on
+    }
+
+    func on(_ substate: Substate) {
+        self.actionHandler(substate)
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Observer.swift
+++ b/ReSwift/CoreTypes/Inversion/Observer.swift
@@ -8,8 +8,8 @@
 
 /// Receives a state update.
 protocol ObserverType {
-    associatedtype Element
-    func on(_ state: Element)
+    associatedtype Substate
+    func on(_ state: Substate)
 }
 
 
@@ -20,7 +20,7 @@ internal struct AnyObserver<Substate>: ObserverType {
         self.actionHandler = actionHandler
     }
 
-    init<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Substate {
+    init<Observer: ObserverType>(_ observer: Observer) where Observer.Substate == Substate {
         self.actionHandler = observer.on
     }
 

--- a/ReSwift/CoreTypes/Inversion/Observer.swift
+++ b/ReSwift/CoreTypes/Inversion/Observer.swift
@@ -12,19 +12,19 @@ protocol ObserverType {
     func on(_ state: Substate)
 }
 
-
-internal struct AnyObserver<Substate>: ObserverType {
-    private let actionHandler: (Substate) -> Void
+/// Type-erased `ObserverType` that forwards events.
+internal final class AnyObserver<Substate>: ObserverType {
+    private let observer: (Substate) -> Void
 
     init(actionHandler: @escaping (Substate) -> Void) {
-        self.actionHandler = actionHandler
+        self.observer = actionHandler
     }
 
     init<Observer: ObserverType>(_ observer: Observer) where Observer.Substate == Substate {
-        self.actionHandler = observer.on
+        self.observer = observer.on
     }
 
     func on(_ substate: Substate) {
-        self.actionHandler(substate)
+        self.observer(substate)
     }
 }

--- a/ReSwift/CoreTypes/Inversion/Observer.swift
+++ b/ReSwift/CoreTypes/Inversion/Observer.swift
@@ -16,8 +16,8 @@ protocol ObserverType {
 internal final class AnyObserver<Substate>: ObserverType {
     private let observer: (Substate) -> Void
 
-    init(actionHandler: @escaping (Substate) -> Void) {
-        self.observer = actionHandler
+    init(observer: @escaping (Substate) -> Void) {
+        self.observer = observer
     }
 
     init<Observer: ObserverType>(_ observer: Observer) where Observer.Substate == Substate {

--- a/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
@@ -1,0 +1,43 @@
+//
+//  Filter.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+final private class Filter<Substate>: Producer<Substate> {
+    typealias Predicate = (Substate) -> Bool
+
+    private let source: Observable<Substate>
+    private let predicate: Predicate
+
+    init(source: Observable<Substate>, predicate: @escaping Predicate) {
+        self.source = source
+        self.predicate = predicate
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Substate  {
+        let sink = FilterSink(predicate: self.predicate, observer: observer, cancel: cancel)
+        let subscription = self.source.subscribe(sink)
+        return (sink, subscription)
+    }
+}
+
+final private class FilterSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Substate = Observer.Element
+    typealias Predicate = (Substate) -> Bool
+
+    private let predicate: Predicate
+
+    init(predicate: @escaping Predicate, observer: Observer, cancel: Cancelable) {
+        self.predicate = predicate
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ state: Substate) {
+        guard self.predicate(state) else { return }
+        self.forward(state: state)
+    }
+}
+

--- a/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
@@ -6,6 +6,12 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
+extension ObservableType {
+    public func filter(_ predicate: @escaping (Substate) -> Bool) -> Observable<Substate> {
+        return Filter(source: self.asObservable(), predicate: predicate)
+    }
+}
+
 final private class Filter<Substate>: Producer<Substate> {
     typealias Predicate = (Substate) -> Bool
 

--- a/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
@@ -17,7 +17,7 @@ final private class Filter<Substate>: Producer<Substate> {
         self.predicate = predicate
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Substate  {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Substate == Substate  {
         let sink = FilterSink(predicate: self.predicate, observer: observer, cancel: cancel)
         let subscription = self.source.subscribe(sink)
         return (sink, subscription)
@@ -25,7 +25,7 @@ final private class Filter<Substate>: Producer<Substate> {
 }
 
 final private class FilterSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
-    typealias Substate = Observer.Element
+    typealias Substate = Observer.Substate
     typealias Predicate = (Substate) -> Bool
 
     private let predicate: Predicate
@@ -40,4 +40,3 @@ final private class FilterSink<Observer: ObserverType>: Sink<Observer>, Observer
         self.forward(state: state)
     }
 }
-

--- a/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Filter.swift
@@ -6,8 +6,16 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
+extension IncompleteSubscription {
+    public func filter(_ predicate: @escaping (Substate) -> Bool) -> IncompleteSubscription<RootStoreState, Substate> {
+        return IncompleteSubscription<RootStoreState, Substate>(
+            store: self.store,
+            observable: self.observable.filter(predicate))
+    }
+}
+
 extension ObservableType {
-    public func filter(_ predicate: @escaping (Substate) -> Bool) -> Observable<Substate> {
+    func filter(_ predicate: @escaping (Substate) -> Bool) -> Observable<Substate> {
         return Filter(source: self.asObservable(), predicate: predicate)
     }
 }
@@ -23,7 +31,12 @@ final private class Filter<Substate>: Producer<Substate> {
         self.predicate = predicate
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Substate == Substate  {
+    override func run<Observer: ObserverType>(
+        _ observer: Observer,
+        cancel: Cancelable
+        ) -> (sink: Disposable, subscription: Disposable)
+        where Observer.Substate == Substate
+    {
         let sink = FilterSink(predicate: self.predicate, observer: observer, cancel: cancel)
         let subscription = self.source.subscribe(sink)
         return (sink, subscription)

--- a/ReSwift/CoreTypes/Inversion/Operators/Select.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Select.swift
@@ -1,0 +1,60 @@
+//
+//  Select.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+extension ObservableType {
+    public func select<Substate>(_ transform: @escaping (Element) -> Substate) -> Observable<Substate> {
+        return self.asObservable().composeMap(transform)
+    }
+}
+
+internal func select<FromState, ToState>(source: Observable<FromState>, transform: @escaping (FromState) -> ToState) -> Observable<ToState> {
+    return Select(source: source, transform: transform)
+}
+
+final private class Select<FromState, ToState>: Producer<ToState> {
+    typealias Source = Observable<FromState>
+    typealias Transform = (FromState) -> ToState
+
+    private let source: Source
+    private let transform: Transform
+
+    init(source: Source, transform: @escaping Transform) {
+        self.source = source
+        self.transform = transform
+    }
+
+    override func composeMap<Substate>(_ outerTransform: @escaping (ToState) -> Substate) -> Observable<Substate> {
+        let innerTransform = self.transform
+        return Select<FromState, Substate>(source: self.source) { (original: FromState) -> Substate in
+            return outerTransform(innerTransform(original))
+        }
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == ToState {
+        let sink = SelectSink(transform: self.transform, observer: observer, cancel: cancel)
+        let subscription = source.subscribe(sink)
+        return (sink, subscription)
+    }
+}
+
+final private class SelectSink<FromState, Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = FromState
+    typealias ToState = Observer.Element
+    typealias Transform = (FromState) -> ToState
+
+    private let transform: Transform
+
+    init(transform: @escaping Transform, observer: Observer, cancel: Cancelable) {
+        self.transform = transform
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ state: FromState) {
+        self.forward(state: self.transform(state))
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Operators/Select.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/Select.swift
@@ -6,13 +6,28 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
+extension IncompleteSubscription {
+    public func select<SelectedSubstate>(
+        _ transform: @escaping (Substate) -> SelectedSubstate
+        ) -> IncompleteSubscription<RootStoreState, SelectedSubstate>
+    {
+        return IncompleteSubscription<RootStoreState, SelectedSubstate>(
+            store: self.store,
+            observable: self.observable.select(transform))
+    }
+}
+
 extension ObservableType {
-    public func select<SelectSubstate>(_ transform: @escaping (Substate) -> SelectSubstate) -> Observable<SelectSubstate> {
+    func select<SelectSubstate>(_ transform: @escaping (Substate) -> SelectSubstate) -> Observable<SelectSubstate> {
         return self.asObservable().composeSelect(transform)
     }
 }
 
-internal func select<FromState, ToState>(source: Observable<FromState>, transform: @escaping (FromState) -> ToState) -> Observable<ToState> {
+internal func select<FromState, ToState>(
+    source: Observable<FromState>,
+    transform: @escaping (FromState) -> ToState
+    ) -> Observable<ToState>
+{
     return Select(source: source, transform: transform)
 }
 
@@ -35,7 +50,12 @@ final private class Select<FromState, ToState>: Producer<ToState> {
         }
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Substate == ToState {
+    override func run<Observer: ObserverType>(
+        _ observer: Observer,
+        cancel: Cancelable
+        ) -> (sink: Disposable, subscription: Disposable)
+        where Observer.Substate == ToState
+    {
         let sink = SelectSink(transform: self.transform, observer: observer, cancel: cancel)
         let subscription = source.subscribe(sink)
         return (sink, subscription)

--- a/ReSwift/CoreTypes/Inversion/Operators/SkipRepeats.swift
+++ b/ReSwift/CoreTypes/Inversion/Operators/SkipRepeats.swift
@@ -1,0 +1,106 @@
+//
+//  SkipRepeats.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+extension IncompleteSubscription where Substate: Equatable {
+    public func skipRepeats() -> IncompleteSubscription<RootStoreState, Substate> {
+        return IncompleteSubscription<RootStoreState, Substate>(
+            store: self.store,
+            observable: self.observable.skipRepeats())
+    }
+}
+
+extension ObservableType where Substate: Equatable {
+    func skipRepeats() -> Observable<Substate> {
+        return self.skipRepeats({ $0 }, comparer: { ($0 == $1) })
+    }
+}
+
+extension IncompleteSubscription {
+    public func skipRepeats<Key: Equatable>(
+        _ keySelector: @escaping (Substate) -> Key
+        ) -> IncompleteSubscription<RootStoreState, Substate>
+    {
+        return self.skipRepeats(keySelector, comparer: { $0 == $1 })
+    }
+
+    public func skipRepeats(
+        _ comparer: @escaping (Substate, Substate) -> Bool
+        ) -> IncompleteSubscription<RootStoreState, Substate>
+    {
+        return self.skipRepeats({ $0 }, comparer: comparer)
+    }
+
+    public func skipRepeats<K>(
+        _ keySelector: @escaping (Substate) -> K,
+        comparer: @escaping (K, K) -> Bool
+        ) -> IncompleteSubscription<RootStoreState, Substate>
+    {
+        return IncompleteSubscription<RootStoreState, Substate>(
+            store: self.store,
+            observable: self.observable.skipRepeats(keySelector, comparer: comparer))
+    }
+}
+
+extension ObservableType {
+    func skipRepeats<K>(_ keySelector: @escaping (Substate) -> K, comparer: @escaping (K, K) -> Bool)
+        -> Observable<Substate> {
+            return SkipRepeats(source: self.asObservable(), selector: keySelector, comparer: comparer)
+    }
+}
+
+final private class SkipRepeats<Substate, Key>: Producer<Substate> {
+    typealias KeySelector = (Substate) -> Key
+    typealias EqualityComparer = (Key, Key) -> Bool
+
+    private let source: Observable<Substate>
+    fileprivate let selector: KeySelector
+    fileprivate let comparer: EqualityComparer
+
+    init(source: Observable<Substate>, selector: @escaping KeySelector, comparer: @escaping EqualityComparer) {
+        self.source = source
+        self.selector = selector
+        self.comparer = comparer
+    }
+
+    override func run<Observer: ObserverType>(
+        _ observer: Observer,
+        cancel: Cancelable)
+        -> (sink: Disposable, subscription: Disposable)
+        where Observer.Substate == Substate
+    {
+        let sink = SkipRepeatsSink(parent: self, observer: observer, cancel: cancel)
+        let subscription = self.source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}
+
+final private class SkipRepeatsSink<Observer: ObserverType, Key>: Sink<Observer>, ObserverType {
+    typealias Substate = Observer.Substate
+
+    private let parent: SkipRepeats<Substate, Key>
+    private var previousValue: Key?
+
+    init(parent: SkipRepeats<Substate, Key>, observer: Observer, cancel: Cancelable) {
+        self.parent = parent
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ state: Substate) {
+        let currentValue = self.parent.selector(state)
+        var areEqual = false
+
+        if let previousValue = self.previousValue {
+            areEqual = self.parent.comparer(previousValue, currentValue)
+        }
+        self.previousValue = currentValue
+
+        guard !areEqual else { return }
+
+        self.forward(state: state)
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Producer.swift
+++ b/ReSwift/CoreTypes/Inversion/Producer.swift
@@ -1,0 +1,59 @@
+//
+//  Producer.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// Override `run` as a callback hook on events coming in.
+internal class Producer<Element>: Observable<Element> {
+    internal override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
+        // The SinkDisposer is returned to manage resources: if it is disposed, its managed resources are disposed, too.
+        let disposer = SinkDisposer()
+        let sinkAndSubscription = self.run(observer, cancel: disposer)
+        disposer.set(sink: sinkAndSubscription.sink, subscription: sinkAndSubscription.subscription)
+        return disposer
+    }
+
+    internal func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) {
+        fatalError("Method not implemented: \(#function)")
+    }
+}
+
+private final class SinkDisposer: Cancelable {
+    private var _sink: Disposable?
+    private var _subscription: Disposable?
+
+    private enum State {
+        case initial, set, disposed
+    }
+
+    private var state: State = .initial
+
+    var isDisposed: Bool {
+        return state == .disposed
+    }
+
+    func set(sink: Disposable, subscription: Disposable) {
+        guard state == .initial else { preconditionFailure("SinkDisposer was set twice") }
+
+        self._sink = sink
+        self._subscription = subscription
+
+        self.state = .set
+    }
+
+    func dispose() {
+        guard state != .disposed else { return }
+
+        guard let sink = self._sink else { preconditionFailure("Sink not set") }
+        guard let subscription = self._subscription else { preconditionFailure("Subscription not set") }
+
+        sink.dispose()
+        subscription.dispose()
+
+        self._sink = nil
+        self._subscription = nil
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Producer.swift
+++ b/ReSwift/CoreTypes/Inversion/Producer.swift
@@ -6,24 +6,46 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
-/// Override `run` as a callback hook on events coming in.
+/// Implements the abstract `Observable.subscribe` to release resources upon disposal.
+/// Delegates the actual grunt work of connecting an event sequence to an observer to
+/// subclasses that implement `run(_:)`.
+///
+/// Notable examples:
+///
+/// - `Observable.create` uses `ObservableEventSource` to produce events at the beginning of
+///    an event sequence. This is the root of all subscriptions.
+/// - Operators like `Select` take an existing sequence and connect their transformers to it
+///   in `run(_:)`, *producing* a resulting sequence.
 internal class Producer<Element>: Observable<Element> {
-    internal override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Substate == Substate {
-        // The SinkDisposer is returned to manage resources: if it is disposed, its managed resources are disposed, too.
+    internal override func subscribe<Observer: ObserverType>(_ observer: Observer)
+        -> Disposable where Observer.Substate == Substate
+    {
+        // SinkDisposer is the ultimate `Cancelable` in the object hierarchy.
         let disposer = SinkDisposer()
         let sinkAndSubscription = self.run(observer, cancel: disposer)
         disposer.set(sink: sinkAndSubscription.sink, subscription: sinkAndSubscription.subscription)
         return disposer
     }
 
-    internal func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) {
+    internal func run<Observer: ObserverType>(
+        _ observer: Observer,
+        cancel: Cancelable
+        ) -> (sink: Disposable, subscription: Disposable)
+    {
         fatalError("Method not implemented: \(#function)")
     }
 }
 
+/// See `Sink` for details; in short, a sink encapsulates event forwarding until it is disposed.
+/// `SinkDisposer` in turn keeps a sink and the resulting subscription in memory together
+/// for as long as the event sequence is retained.
+///
+/// This is at the root of observable event sequences. When the initial sequence is disposed,
+/// this object will release the strong references to `sink` and `subscription` once, invoking
+/// their `dispose()` callbacks in return.
 private final class SinkDisposer: Cancelable {
-    private var _sink: Disposable?
-    private var _subscription: Disposable?
+    private var sink: Disposable?
+    private var subscription: Disposable?
 
     private enum State {
         case initial, set, disposed
@@ -37,23 +59,23 @@ private final class SinkDisposer: Cancelable {
 
     func set(sink: Disposable, subscription: Disposable) {
         guard state == .initial else { preconditionFailure("SinkDisposer was set twice") }
-
-        self._sink = sink
-        self._subscription = subscription
-
         self.state = .set
+
+        self.sink = sink
+        self.subscription = subscription
     }
 
     func dispose() {
         guard state != .disposed else { return }
+        self.state = .disposed
 
-        guard let sink = self._sink else { preconditionFailure("Sink not set") }
-        guard let subscription = self._subscription else { preconditionFailure("Subscription not set") }
+        guard let sink = self.sink else { preconditionFailure("Sink not set") }
+        guard let subscription = self.subscription else { preconditionFailure("Subscription not set") }
 
         sink.dispose()
         subscription.dispose()
 
-        self._sink = nil
-        self._subscription = nil
+        self.sink = nil
+        self.subscription = nil
     }
 }

--- a/ReSwift/CoreTypes/Inversion/Producer.swift
+++ b/ReSwift/CoreTypes/Inversion/Producer.swift
@@ -8,7 +8,7 @@
 
 /// Override `run` as a callback hook on events coming in.
 internal class Producer<Element>: Observable<Element> {
-    internal override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
+    internal override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Substate == Substate {
         // The SinkDisposer is returned to manage resources: if it is disposed, its managed resources are disposed, too.
         let disposer = SinkDisposer()
         let sinkAndSubscription = self.run(observer, cancel: disposer)

--- a/ReSwift/CoreTypes/Inversion/Producer.swift
+++ b/ReSwift/CoreTypes/Inversion/Producer.swift
@@ -16,7 +16,7 @@
 ///    an event sequence. This is the root of all subscriptions.
 /// - Operators like `Select` take an existing sequence and connect their transformers to it
 ///   in `run(_:)`, *producing* a resulting sequence.
-internal class Producer<Element>: Observable<Element> {
+internal class Producer<Substate>: Observable<Substate> {
     internal override func subscribe<Observer: ObserverType>(_ observer: Observer)
         -> Disposable where Observer.Substate == Substate
     {

--- a/ReSwift/CoreTypes/Inversion/Sink.swift
+++ b/ReSwift/CoreTypes/Inversion/Sink.swift
@@ -1,0 +1,32 @@
+//
+//  Sink.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-03.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// It's a thing that can be disposed and forwards events to observers.
+/// When disposed, it will not forward future events.
+internal class Sink<Observer: ObserverType>: Disposable {
+    internal let observer: Observer
+    internal let cancel: Cancelable
+
+    init(observer: Observer, cancel: Cancelable) {
+        self.observer = observer
+        self.cancel = cancel
+    }
+
+    final func forward(state: Observer.Element) {
+        guard !isDisposed else { return }
+        self.observer.on(state)
+    }
+
+    // TODO: Use NSLock/atomic values for thread safety
+    private var isDisposed: Bool = false
+
+    func dispose() {
+        self.isDisposed = true
+        cancel.dispose()
+    }
+}

--- a/ReSwift/CoreTypes/Inversion/Sink.swift
+++ b/ReSwift/CoreTypes/Inversion/Sink.swift
@@ -17,7 +17,7 @@ internal class Sink<Observer: ObserverType>: Disposable {
         self.cancel = cancel
     }
 
-    final func forward(state: Observer.Element) {
+    final func forward(state: Observer.Substate) {
         guard !isDisposed else { return }
         self.observer.on(state)
     }

--- a/ReSwift/CoreTypes/Inversion/Sink.swift
+++ b/ReSwift/CoreTypes/Inversion/Sink.swift
@@ -6,8 +6,19 @@
 //  Copyright © 2019 ReSwift. All rights reserved.
 //
 
-/// It's a thing that can be disposed and forwards events to observers.
-/// When disposed, it will not forward future events.
+/// A Sink represents a disposable connection to an observer. Think of it as a cancelable
+/// wrapper that forwards events.
+///
+/// - `observer` receives events as long as `isDisposed == false`.
+/// - `dispose` forwards resource cleanup commands to the `cancel` handler.
+///
+/// ## Subclassing Notes
+///
+/// Subclass `Sink` for operators to inherit the resource cleanup.
+/// Call `forward(state:)` to pass on events to eventual observers.
+///
+/// You could also delegate to a `Sink` instance instead of subclassing, but
+/// the convenience of inheriting `Disposable` would then be lost.
 internal class Sink<Observer: ObserverType>: Disposable {
     internal let observer: Observer
     internal let cancel: Cancelable
@@ -26,6 +37,7 @@ internal class Sink<Observer: ObserverType>: Disposable {
     private var isDisposed: Bool = false
 
     func dispose() {
+        guard !isDisposed else { return }
         self.isDisposed = true
         cancel.dispose()
     }

--- a/ReSwift/CoreTypes/Inversion/SubscriptionToken.swift
+++ b/ReSwift/CoreTypes/Inversion/SubscriptionToken.swift
@@ -1,0 +1,50 @@
+//
+//  SubscriptionToken.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+/// Can be used to unsubscribe single subscriptions if an object should have multiple active subscriptions.
+public final class SubscriptionToken: Hashable {
+    private let objectIdentifier: ObjectIdentifier
+
+    internal let subscriber: AnyObject
+    internal let disposable: Disposable?
+
+    internal init(subscriber: AnyObject, disposable: Disposable?) {
+        self.subscriber = subscriber
+        self.disposable = disposable
+        self.objectIdentifier = ObjectIdentifier(subscriber)
+    }
+
+    internal func isRepresenting(subscriber: AnyStoreSubscriber) -> Bool {
+        return self.subscriber === subscriber
+    }
+
+    public static func == (lhs: SubscriptionToken, rhs: SubscriptionToken) -> Bool {
+
+        return lhs.objectIdentifier == rhs.objectIdentifier
+    }
+
+    #if swift(>=5.0)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.objectIdentifier)
+    }
+    #elseif swift(>=4.2)
+    #if compiler(>=5.0)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.objectIdentifier)
+    }
+    #else
+    public var hashValue: Int {
+        return self.objectIdentifier.hashValue
+    }
+    #endif
+    #else
+    public var hashValue: Int {
+        return self.objectIdentifier.hashValue
+    }
+    #endif
+}

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -34,6 +34,7 @@ open class Store<State: StateType>: StoreType {
     private var reducer: Reducer<State>
 
     var subscriptions: Set<SubscriptionType> = []
+    var subscriptionTokens: Set<SubscriptionToken> = []
 
     private var isDispatching = false
 
@@ -139,6 +140,7 @@ open class Store<State: StateType>: StoreType {
 
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {
         removeSubscription(subscriber: subscriber)
+        removeAllSubscriptionTokens(subscriber: subscriber)
     }
 
     private func removeSubscription(subscriber: AnyStoreSubscriber) {
@@ -151,6 +153,14 @@ open class Store<State: StateType>: StoreType {
             subscriptions.remove(at: index)
         }
         #endif
+    }
+
+    private func removeAllSubscriptionTokens(subscriber: AnyStoreSubscriber) {
+        let matchingTokens = subscriptionTokens
+            .filter { $0.isRepresenting(subscriber: subscriber) }
+        for matchingToken in matchingTokens {
+            subscriptionTokens.remove(matchingToken)
+        }
     }
 
     // swiftlint:disable:next identifier_name

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -133,6 +133,10 @@ open class Store<State: StateType>: StoreType {
         )
     }
 
+    public func subscription() -> IncompleteSubscription<State, State> {
+        return IncompleteSubscription(store: self, observable: self.asObservable())
+    }
+
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {
         #if swift(>=5.0)
         if let index = subscriptions.firstIndex(where: { return $0.subscriber === subscriber }) {

--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -138,6 +138,10 @@ open class Store<State: StateType>: StoreType {
     }
 
     open func unsubscribe(_ subscriber: AnyStoreSubscriber) {
+        removeSubscription(subscriber: subscriber)
+    }
+
+    private func removeSubscription(subscriber: AnyStoreSubscriber) {
         #if swift(>=5.0)
         if let index = subscriptions.firstIndex(where: { return $0.subscriber === subscriber }) {
             subscriptions.remove(at: index)

--- a/ReSwiftTests/BlockSubscriberTests.swift
+++ b/ReSwiftTests/BlockSubscriberTests.swift
@@ -1,0 +1,46 @@
+//
+//  BlockSubscriberTests.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+import XCTest
+@testable import ReSwift
+
+class BlockSubscriberTests: XCTestCase {
+
+    func testBlock() {
+        let reducer = TestValueStringReducer()
+        let state = TestStringAppState()
+        let store = Store(
+            reducer: reducer.handleAction,
+            state: state,
+            middleware: [],
+            automaticallySkipsRepeats: true)
+
+        var receivedValue: TestStringAppState? = nil
+        var newStateCallCount = 0
+        let subscriber = BlockSubscriber<TestStringAppState> {
+            receivedValue = $0
+            newStateCallCount += 1
+        }
+
+        store.subscribe(subscriber)
+
+        XCTAssertEqual(receivedValue?.testValue, "Initial")
+        XCTAssertEqual(newStateCallCount, 1)
+
+        store.dispatch(SetValueStringAction("Initial"))
+
+        XCTAssertEqual(receivedValue?.testValue, "Initial")
+        XCTAssertEqual(newStateCallCount, 1)
+
+        store.dispatch(SetValueStringAction("New"))
+
+        XCTAssertEqual(receivedValue?.testValue, "New")
+        XCTAssertEqual(newStateCallCount, 2)
+    }
+
+}

--- a/ReSwiftTests/DisposableTests.swift
+++ b/ReSwiftTests/DisposableTests.swift
@@ -1,0 +1,27 @@
+//
+//  DisposableTests.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+import XCTest
+@testable import ReSwift
+
+class DisposableTests: XCTestCase {
+
+    func testDisposableClosureIsExecutedOnlyOnce() {
+        var counter = 0
+
+        let disposable = createDisposable {
+            counter += 1
+        }
+
+        XCTAssertEqual(counter, 0)
+        disposable.dispose()
+        XCTAssertEqual(counter, 1)
+        disposable.dispose()
+        XCTAssertEqual(counter, 1)
+    }
+}

--- a/ReSwiftTests/IncompleteSubscriptionTests.swift
+++ b/ReSwiftTests/IncompleteSubscriptionTests.swift
@@ -1,0 +1,52 @@
+//
+//  IncompleteSubscriptionTests.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift Community. All rights reserved.
+//
+
+import XCTest
+import ReSwift
+
+class IncompleteSubscriptionTests: XCTestCase {
+
+    func testPassesOnRootState() {
+        let reducer = TestValueStringReducer()
+        let state = TestStringAppState()
+        let store = Store(reducer: reducer.handleAction, state: state, middleware: [])
+        let subscriber = TestFilteredSubscriber<TestStringAppState>()
+
+        store.subscription()
+            .subscribe(subscriber)
+
+        XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
+
+        store.dispatch(SetValueStringAction("Initial"))
+
+        XCTAssertEqual(subscriber.receivedValue.testValue, "Initial")
+        XCTAssertEqual(subscriber.newStateCallCount, 1)
+    }
+
+    func testPassesOnSelectedSubstate() {
+        let reducer = TestReducer()
+        let store = Store(reducer: reducer.handleAction, state: TestAppState())
+        let subscriber = TestFilteredSubscriber<Int?>()
+
+        store.subscription()
+            .select { $0.testValue }
+            .subscribe(subscriber)
+
+        store.dispatch(SetValueAction(3))
+
+        XCTAssertEqual(subscriber.receivedValue, 3)
+
+        store.dispatch(SetValueAction(nil))
+
+        #if swift(>=4.1)
+        XCTAssertEqual(subscriber.receivedValue, .some(.none))
+        #else
+        XCTAssertEqual(subscriber.receivedValue, nil)
+        #endif
+    }
+}

--- a/ReSwiftTests/ObservableTests.swift
+++ b/ReSwiftTests/ObservableTests.swift
@@ -1,0 +1,59 @@
+//
+//  ObservableTests.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+import XCTest
+@testable import ReSwift
+
+class ObservableTests: XCTestCase {
+
+    class Observer: ObserverType {
+        var didReceive: Int?
+        func on(_ state: Int) {
+            didReceive = state
+        }
+    }
+
+    func testObservableCreationItselfDoesNotCallTheCreationClosure() {
+        var wasCalled = false
+        let observable = Observable<Int>.create { _ in
+            wasCalled = true
+            return createDisposable()
+        }
+
+        XCTAssertFalse(wasCalled)
+    }
+
+    func testConnectingObservableAffectsObserverIndividually() {
+        var count = 0
+        let events = Observable<Int>.create { observer in
+            count += 1
+            observer.on(count)
+            return createDisposable()
+        }
+
+        let firstObserver = Observer()
+        let secondObserver = Observer()
+        var subscriptions: [Disposable] = []
+
+        // Precondition
+        XCTAssertNil(firstObserver.didReceive)
+        XCTAssertNil(secondObserver.didReceive)
+
+        // Subscription executes `create` closure
+        subscriptions.append(events.subscribe(firstObserver))
+        XCTAssertEqual(firstObserver.didReceive, 1)
+
+        // Further subscriptions execute `create` closure for the new observer only
+        subscriptions.append(events.subscribe(secondObserver))
+        XCTAssertEqual(firstObserver.didReceive, 1)
+        XCTAssertEqual(secondObserver.didReceive, 2)
+
+        subscriptions = []
+    }
+
+}

--- a/ReSwiftTests/ObserverTests.swift
+++ b/ReSwiftTests/ObserverTests.swift
@@ -1,0 +1,36 @@
+//
+//  ObserverTests.swift
+//  ReSwift
+//
+//  Created by Christian Tietze on 2019-08-05.
+//  Copyright © 2019 ReSwift. All rights reserved.
+//
+
+import XCTest
+@testable import ReSwift
+
+class ObserverTests: XCTestCase {
+
+    func testConvenienceOn_Next() {
+        var observer: AnyObserver<Int>!
+        let events: Observable<Int> = Observable.create { obs in
+            observer = obs
+            return createDisposable()
+        }
+
+        var elements = [Int]()
+
+        let subscription = events.subscribe { value in
+            elements.append(value)
+        }
+
+        XCTAssertEqual(elements, [])
+
+        observer.on(0)
+
+        XCTAssertEqual(elements, [0])
+
+        subscription.dispose()
+    }
+
+}

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -169,19 +169,6 @@ class TestStoreSubscriber<T>: StoreSubscriber {
     }
 }
 
-class BlockSubscriber<S>: StoreSubscriber {
-    typealias StoreSubscriberStateType = S
-    private let block: (S) -> Void
-
-    init(block: @escaping (S) -> Void) {
-        self.block = block
-    }
-
-    func newState(state: S) {
-        self.block(state)
-    }
-}
-
 class DispatchingSubscriber: StoreSubscriber {
     var store: Store<TestAppState>
 

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -20,8 +20,8 @@ struct TestAppState: StateType {
 struct TestStringAppState: StateType {
     var testValue: String
 
-    init() {
-        testValue = "Initial"
+    init(testValue: String = "Initial") {
+        self.testValue = testValue
     }
 }
 


### PR DESCRIPTION
Backstory: @mjarvis started this in #307 about 2 years ago. The way the ReSwift.Store is set up, his initial approach created a subscription right away. I suggested and tried to help with an approach where apps would have a `PendingSubscription` that only at the `subscribe()` call would be added to the Store.

But this didn't work out well in practice and both Malcolm and I have practically given up for the time being :)

With my recent adventures into the realm of making Middleware calls simpler, I experimented with another way to dispatch actions, and found it would fit ReSwift quite well.

This is a sample call:

```swift
store.subscription()
    .select { $0.substate.anotherSubstate }
    .skipRepeats()
    .subscribe()
```

**This code heavily borrows concepts and implementation from RxSwift.** I had quite some trouble wrapping my had around the concepts to be able to implement them properly.

A couple of notes regarding the reactive nature, aka how the inversion is done:

- State updates are passed on as events in a reactive sequence, aka `Observable<State>`
- State update events are produced via a `BlockSubscriber`: it forwards `newState` calls to a block which is set from the outside as a callback to pass events down the Observable stream using `Observable.create`
- `Observable.create` sounds like you'd create the event stream itself, similar to creating arrays; but it ain't so. Instead, you define the connection/subscription from Observable to its Observer counterpart.
- In fact, every transformation operator (select, filter, skipRepeats) adds another Observer on top that forwards events to the next one. The observable sequence is really a chain of observers passing on events, starting with the initial connection you specify in `Observable.create`.
- The actual `StoreSubscriberType` in an app is not subscribed to the store anymore, just the `BlockSubscriber` is; the app's subscribers receive updates via the observable/observer chain.
- `BlockSubscriber` is prepared in `Observable.create` to be subscribed to the store itself -- but the subscription is only executed when a connection happens. This is fun, and also weird, because I _think_ about the creation first, like a "hot" sequence that just begins pumping out events, just but it is actually executed very late and, in some sense, lazily.

By using `Observable` and its observers, you can model transformations with operators without actually having a functional store subscription.

I left extensive comments in the code to make sense of the subleties of memory management. I still want to get rid of most parts of it. The dual of an `Observable` operator and its `Sink`, which is just an _observer_ that applies the transformations and conditionally forwards the result to the next in the chain, will probably stick. But the `Producer` type, wrapping each step's objects in a cancelable objects with strongly references to its parts, maybe we can ditch that kind of stuff.

# Important types

## IncompleteSubscription

I went with @mjarvis's API, starting with `Store.subscription() -> IncompleteSubscription<Store.State, Store.State>`.  The `IncompleteSubscription<RootStoreState, Substate>` tracks the root state type of the store so you cannot create an `IncompleteSubscription` in one store and stuff it into another, unless both use the same state type. `.select` operations modify the `Substate` associated type accordingly while `RootStoreState` stays the same.

`IncompleteSubscription` is the user-facing API. Observables and such are internal implementation details. Each operation replaces its underlying `Observable<Substate>`.

## SubscriptionToken

Problem with hiding the actual subscription to the store in a hidden `BlockSubscriber` is that users cannot unsubscribe the _real_ subscriber. They only know the object they passed in. (Let's call the one users own the "user-facing subscriber".)

I created `SubscriptionToken` to introduce a different state update mechanism _in addition to notifiying all subscribers_. You can unsubscribe each token individually, like regular subscribers. You can also still call `Store.unsubscribe` with the user-facing subscriber and all corresponding tokens will be removed. The tokens keep a strong reference to the observable connection, represented by the `Disposable` type; it receives the `dispose()` command when the token is deallocated. This breaks the connection and eventually frees the underlying `BlockSubscriber` as well.

------

Things I know are still missing:

- [ ] add tests for `Filter`, if we need that operator at all, that is
- [ ] test if it crashes expectedly or works properly from multiple threads
- [ ] remove the v4 `SubscriptionBox` types etc. that introduced the "old" transformations, and revert this to the most basic ReSwift v2 `Subscription`s. (We still need these for the `BlockSubscriber` to receive events, unless we remove the whole object-based subscription thing completely from the public API)
- [ ] avoid double `skipRepeats`: if `automaticallySkipRepeats` is enabled, figure out if the latest operator is a `skipRepeats` as well (a simple boolean for `IncompleteSubscription` could do, or an type association to the `SkipRepeats` operator type itself)

I'd love to have your feedback on this! PRs to the branch of this PR are also very welcome if you want to play around with it! :)