### PR TITLE
delete escaping for subscription constructor where sink closuer be called immediately

### DIFF
--- a/ReSwift/CoreTypes/Subscription.swift
+++ b/ReSwift/CoreTypes/Subscription.swift
@@ -97,7 +97,7 @@ public class Subscription<State> {
 
     /// Initializes a subscription with a sink closure. The closure provides a way to send
     /// new values over this subscription.
-    public init(sink: @escaping (@escaping (State?, State) -> Void) -> Void) {
+    public init(sink: (@escaping (State?, State) -> Void) -> Void) {
         // Provide the caller with a closure that will forward all values
         // to observers of this subscription.
         sink { old, new in


### PR DESCRIPTION
`
public class Subscription<State> {

    /// Initializes a subscription with a sink closure. The closure provides a way to send
    /// new values over this subscription.
    public init(sink: @escaping (@escaping (State?, State) -> Void) -> Void) {
        // Provide the caller with a closure that will forward all values
        // to observers of this subscription.
        sink { old, new in
            self.newValues(oldState: old, newState: new)
        }
    }
}
`

sink clouser called immediately,  not need use @escaping 

